### PR TITLE
Add CC BY 4.0 license for open source documentation

### DIFF
--- a/.github/SUMMARY.md
+++ b/.github/SUMMARY.md
@@ -1,8 +1,17 @@
 # Summary of Changes - Zimbabwe Travel Information
 
-**Date:** November 21, 2025
+**Date:** December 1, 2025
 **Branch:** main
-**Commit:** bf4268b
+
+---
+
+## Project Overview
+
+Zimbabwe Travel Information is an open source documentation site providing comprehensive travel guides for Zimbabwe. The content is licensed under **Creative Commons Attribution 4.0 International (CC BY 4.0)**.
+
+- **Website:** [travel-info.co.zw](https://travel-info.co.zw)
+- **License:** [CC BY 4.0](../LICENSE)
+- **Built with:** [Mintlify](https://mintlify.com)
 
 ---
 
@@ -166,6 +175,7 @@ bash .github/run-seo-update.sh --dirs=./destinations,./planning
 - [x] Downloaded 1 working image
 - [x] Created all utility scripts
 - [x] Converted SEO workflow to manual script
+- [x] Added CC BY 4.0 open source license
 - [x] Pushed all changes to main branch
 
 ### ⚠️ Needs Manual Work
@@ -233,6 +243,8 @@ bash .github/run-seo-update.sh --dirs=./destinations,./planning
 - **6 scripts created:** Utility automation
 - **17 images added:** 1 complete, 16 need re-download
 - **1 guide created:** IMAGE_DOWNLOAD_GUIDE.md
+- **LICENSE:** CC BY 4.0 open source license
+- **package.json:** Added project metadata and license field
 
 ---
 
@@ -244,8 +256,9 @@ bash .github/run-seo-update.sh --dirs=./destinations,./planning
 - Images stored in `/images/` will be automatically served by Mintlify
 - Photo credits must be maintained when using images
 - Bot protection on Pixabay can be bypassed with manual downloads
+- Project licensed under CC BY 4.0 - attribution required for reuse
 
 ---
 
-**Last Updated:** 2025-11-21
+**Last Updated:** 2025-12-01
 **Status:** Ready for image manual download

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,35 @@
+Creative Commons Attribution 4.0 International (CC BY 4.0)
+
+Copyright (c) 2025 Zimbabwe Travel Information
+
+You are free to:
+
+  Share - copy and redistribute the material in any medium or format
+  Adapt - remix, transform, and build upon the material for any purpose,
+          even commercially
+
+Under the following terms:
+
+  Attribution - You must give appropriate credit, provide a link to the
+                license, and indicate if changes were made. You may do so
+                in any reasonable manner, but not in any way that suggests
+                the licensor endorses you or your use.
+
+  No additional restrictions - You may not apply legal terms or
+                               technological measures that legally
+                               restrict others from doing anything the
+                               license permits.
+
+Notices:
+
+  You do not have to comply with the license for elements of the material
+  in the public domain or where your use is permitted by an applicable
+  exception or limitation.
+
+  No warranties are given. The license may not give you all of the
+  permissions necessary for your intended use. For example, other rights
+  such as publicity, privacy, or moral rights may limit how you use the
+  material.
+
+For the full license text, see:
+https://creativecommons.org/licenses/by/4.0/legalcode

--- a/README.md
+++ b/README.md
@@ -79,4 +79,8 @@ We welcome contributions! If you have suggestions for improving our travel guide
 
 ## License
 
-Content is for informational purposes. Please verify important details (visa requirements, health advisories, etc.) with official sources before traveling.
+This work is licensed under a [Creative Commons Attribution 4.0 International License](LICENSE).
+
+You are free to share and adapt this content with appropriate attribution.
+
+**Note:** Please verify important details (visa requirements, health advisories, etc.) with official sources before traveling.

--- a/package.json
+++ b/package.json
@@ -1,4 +1,13 @@
 {
+  "name": "zti-docs",
+  "description": "Zimbabwe Travel Information - Open source documentation for travel guides",
+  "version": "1.0.0",
+  "license": "CC-BY-4.0",
+  "homepage": "https://travel-info.co.zw",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nyuchitech/zti-docs"
+  },
   "devDependencies": {
     "gray-matter": "^4.0.3"
   }


### PR DESCRIPTION
Add Creative Commons Attribution 4.0 International license, which is
appropriate for documentation/content sites. Update README to reference
the license file.