### PR TITLE
Add Heritage & History section with categories inspired by ZimFieldGuide

### DIFF
--- a/FUTURE_PAGES_PLAN.md
+++ b/FUTURE_PAGES_PLAN.md
@@ -1,0 +1,362 @@
+# Future Pages Plan for Zimbabwe Travel Information
+
+This document outlines potential pages to build based on the existing site structure and competitor analysis from ZimFieldGuide. Pages are organized by category with priority levels.
+
+---
+
+## Summary
+
+| Category | Current Pages | Potential Additions | Priority |
+|----------|---------------|---------------------|----------|
+| Rock Art | 7 | 15+ | High |
+| Scenic/Waterfalls | 7 | 20+ | High |
+| Geological | 3 | 10+ | Medium |
+| Historic | 2 | 15+ | Medium |
+| Heritage/Ruins | 6 | 10+ | High |
+| Game Parks/Wildlife | 3 | 15+ | High |
+| Destinations | 24 | 20+ | Medium |
+| Culture | 6 | 10+ | Medium |
+| Adventure | 7 | 10+ | Low |
+
+---
+
+## 1. Rock Art Sites (High Priority)
+
+ZimFieldGuide has 35 rock art entries. We have 7. Major gaps:
+
+### Matobo Region (Add 5-8 pages)
+- [ ] `rock-art/silozwane-cave.mdx` - Major cave with ceiling paintings
+- [ ] `rock-art/inanke-cave.mdx` - Most extensive paintings (difficult access)
+- [ ] `rock-art/white-rhino-shelter.mdx` - Famous rhino paintings
+- [ ] `rock-art/bambata-cave.mdx` - Archaeological significance
+- [ ] `rock-art/gulubahwe-cave.mdx` - Remote but significant site
+- [ ] `rock-art/nswatugi-area-sites.mdx` - Minor sites around Nswatugi
+
+### Mashonaland Region (Add 5-8 pages)
+- [ ] `rock-art/makumbe-cave.mdx` - Near Harare
+- [ ] `rock-art/chinamora-sites.mdx` - Chinamora communal lands
+- [ ] `rock-art/diana's-vow.mdx` - Famous "formling" paintings
+- [ ] `rock-art/kasimba-cave.mdx` - Eastern districts
+- [ ] `rock-art/rusape-sites.mdx` - Eastern Highlands rock art
+- [ ] `rock-art/mvurwi-area.mdx` - Northern sites
+
+### Other Regions
+- [ ] `rock-art/gonarezhou-sites.mdx` - Chilojo area rock art
+- [ ] `rock-art/hwange-sites.mdx` - Rock art in Hwange area
+- [ ] `rock-art/victoria-falls-area.mdx` - Zambezi region sites
+
+---
+
+## 2. Scenic Viewpoints & Natural Wonders (High Priority)
+
+ZimFieldGuide has 60 scenic entries. Major gaps:
+
+### Waterfalls (Add 10+ pages)
+- [ ] `scenic/nyangombe-falls.mdx` - Popular Nyanga waterfall with swimming
+- [ ] `scenic/turaco-falls.mdx` - Nyanga area
+- [ ] `scenic/odzani-falls.mdx` - Near Mutare
+- [ ] `scenic/nyamuziwa-falls.mdx` - Remote Nyanga falls
+- [ ] `scenic/brighton-beach-nyanga.mdx` - Scenic cascade area
+- [ ] `scenic/mukurupiri-falls.mdx` - Lesser-known Eastern Highlands
+- [ ] `scenic/honde-valley-waterfalls.mdx` - Multiple falls overview
+- [ ] `scenic/chimanimani-falls.mdx` - Falls within Chimanimani
+- [ ] `scenic/mazowe-falls.mdx` - Near Harare day trip
+- [ ] `scenic/gairezi-falls.mdx` - Remote border area
+
+### Viewpoints (Add 8+ pages)
+- [ ] `scenic/cecil-kop.mdx` - Near Mutare viewpoint
+- [ ] `scenic/christmas-pass.mdx` - Famous mountain pass
+- [ ] `scenic/vumba-viewpoints.mdx` - Bvumba area overlooks
+- [ ] `scenic/skeleton-pass.mdx` - Dramatic Nyanga viewpoint
+- [ ] `scenic/mount-nyangani-summit.mdx` - Zimbabwe's highest point
+- [ ] `scenic/pungwe-gorge.mdx` - Dramatic gorge views
+- [ ] `scenic/mutarazi-viewpoints.mdx` - Extended viewpoint guide
+- [ ] `scenic/chirinda-forest-viewpoints.mdx` - Ancient forest overlooks
+
+### Natural Features
+- [ ] `scenic/save-river-confluence.mdx` - River meeting point
+- [ ] `scenic/mana-pools-pans.mdx` - Iconic seasonal pans
+- [ ] `scenic/kariba-sunsets.mdx` - Best sunset spots
+
+---
+
+## 3. Geological Features (Medium Priority)
+
+ZimFieldGuide has 18 geological entries. We have 3.
+
+### Rock Formations (Add 8+ pages)
+- [ ] `geological/epworth-balancing-rocks.mdx` - Iconic national symbol
+- [ ] `geological/domboshava-rocks.mdx` - Geological focus (vs rock art page)
+- [ ] `geological/chiremba-rocks.mdx` - Epworth area
+- [ ] `geological/great-dyke.mdx` - Major geological feature
+- [ ] `geological/matobo-kopjes.mdx` - Formation explanation
+- [ ] `geological/hwange-fossil-forest.mdx` - Petrified forest
+- [ ] `geological/castle-kopje.mdx` - Near Wedza
+
+### Cave Systems
+- [ ] `geological/sinoia-caves-geology.mdx` - Detailed geological guide
+- [ ] `geological/chiburi-cave.mdx` - Near Chinhoyi
+- [ ] `geological/nyamakwe-cave.mdx` - Lesser-known cave
+- [ ] `geological/bat-cave-matobo.mdx` - Accessible cave
+
+### Springs & Hot Springs
+- [ ] `geological/chimanimani-hot-springs.mdx` - Natural hot springs
+- [ ] `geological/nyamandhlovhu-pan.mdx` - Natural salt pan
+- [ ] `geological/mpopoma-springs.mdx` - Natural springs
+
+---
+
+## 4. Historic Sites (Medium Priority)
+
+ZimFieldGuide has 40 building entries and 192 historic entries. We have 2.
+
+### Colonial Era (Add 10+ pages)
+- [ ] `historic/cecil-square-harare.mdx` - Historic city center
+- [ ] `historic/meikles-hotel.mdx` - Historic Harare landmark
+- [ ] `historic/victoria-falls-hotel.mdx` - Historic hotel (1904)
+- [ ] `historic/bulawayo-club.mdx` - Historic members club
+- [ ] `historic/nesbitt-castle.mdx` - Gothic castle near Bulawayo
+- [ ] `historic/railway-museum.mdx` - Bulawayo railway history
+- [ ] `historic/natural-history-museum.mdx` - Bulawayo museum
+- [ ] `historic/queen-victoria-museum.mdx` - Harare museum
+- [ ] `historic/national-archives.mdx` - Historical records
+- [ ] `historic/old-bulawayo.mdx` - Reconstructed royal kraal
+
+### Religious Buildings
+- [ ] `historic/cyrene-mission.mdx` - Famous art school mission
+- [ ] `historic/domboshawa-mission.mdx` - Historic mission station
+- [ ] `historic/cathedral-of-mary.mdx` - Harare cathedral
+- [ ] `historic/centenary-church.mdx` - Bulawayo church
+
+### War & Liberation
+- [ ] `historic/liberation-war-sites.mdx` - Overview of Chimurenga sites
+- [ ] `historic/nhari-rebellion-sites.mdx` - 1896 uprising
+- [ ] `historic/heroes-acre-harare.mdx` - National monument
+- [ ] `historic/heroes-acre-bulawayo.mdx` - Provincial monument
+- [ ] `historic/shangani-memorial.mdx` - Colonial memorial in Matobo
+
+### Rhodes Era
+- [ ] `historic/rhodes-grave.mdx` - Standalone detailed guide
+- [ ] `historic/rhodes-inyanga.mdx` - Rhodes estates in Nyanga
+
+---
+
+## 5. Ancient Ruins (High Priority)
+
+ZimFieldGuide has 25 ruins entries. We have 6.
+
+### Stone Ruins (Add 8+ pages)
+- [ ] `heritage/regina-ruins.mdx` - Near Harare
+- [ ] `heritage/rozvi-sites.mdx` - Multiple Rozvi state sites
+- [ ] `heritage/inyanga-ruins.mdx` - Stone forts and terraces
+- [ ] `heritage/nyahokwe-ruins.mdx` - Nyanga terraced site
+- [ ] `heritage/chawomera-fort.mdx` - Portuguese trading post
+- [ ] `heritage/luanze-ruins.mdx` - Trading center remains
+- [ ] `heritage/dambarare-ruins.mdx` - Portuguese gold fair site
+- [ ] `heritage/mtoko-ruins.mdx` - Stone structures in Mashonaland
+
+### Mining & Industrial Heritage
+- [ ] `heritage/old-gold-mines.mdx` - Ancient mining sites overview
+- [ ] `heritage/iron-age-furnaces.mdx` - Metal working sites
+- [ ] `heritage/terracing-systems.mdx` - Agricultural terraces
+
+---
+
+## 6. Game Parks & Wildlife Areas (High Priority)
+
+ZimFieldGuide has 59 game park entries. Current wildlife section lacks individual park pages.
+
+### National Parks (Add 10+ pages)
+- [ ] `wildlife/kazungula-game-park.mdx` - Border area park
+- [ ] `wildlife/chizarira-national-park.mdx` - Remote wilderness
+- [ ] `wildlife/victoria-falls-rainforest.mdx` - Unique ecosystem
+- [ ] `wildlife/zambezi-national-park.mdx` - Victoria Falls area park
+- [ ] `wildlife/nyanga-national-park.mdx` - Wildlife in mountains
+- [ ] `wildlife/chimanimani-national-park.mdx` - Wilderness area
+
+### Private Game Reserves
+- [ ] `wildlife/malilangwe-reserve.mdx` - Luxury conservation
+- [ ] `wildlife/save-valley-conservancy.mdx` - Rhino program
+- [ ] `wildlife/bubye-valley-conservancy.mdx` - Largest private reserve
+- [ ] `wildlife/midlands-black-rhino.mdx` - Rhino conservancy
+- [ ] `wildlife/imire-game-park.mdx` - Rhino breeding
+- [ ] `wildlife/pamuzinda-safari-lodge.mdx` - Near Harare
+- [ ] `wildlife/antelope-park.mdx` - Near Gweru
+
+### Safari Camps & Concessions
+- [ ] `wildlife/ruckomechi-camp.mdx` - Mana Pools iconic camp
+- [ ] `wildlife/chikwenya-camp.mdx` - Mana Pools eastern
+- [ ] `wildlife/makalolo-plains.mdx` - Hwange prime area
+- [ ] `wildlife/somalisa-concession.mdx` - Hwange private area
+
+### Bird Sanctuaries
+- [ ] `wildlife/lake-chivero-bird-sanctuary.mdx` - Birdwatching hotspot
+- [ ] `wildlife/mukuvisi-woodlands.mdx` - Urban nature reserve
+- [ ] `wildlife/ewanrigg-gardens.mdx` - Botanical/bird site
+
+---
+
+## 7. Cities & Towns (Medium Priority)
+
+### Cities Not Yet Covered
+- [ ] `destinations/kadoma.mdx` - Mining town
+- [ ] `destinations/kwekwe.mdx` - Central town
+- [ ] `destinations/victoria-falls-town.mdx` - Town guide vs falls
+- [ ] `destinations/karoi.mdx` - Farming town
+- [ ] `destinations/bindura.mdx` - Mining center
+- [ ] `destinations/rusape.mdx` - Eastern gateway
+- [ ] `destinations/chipinge.mdx` - Coffee/tea town
+- [ ] `destinations/chiredzi.mdx` - Sugar town, Gonarezhou gateway
+
+### Township & Suburban Guides
+- [ ] `destinations/mbare-market.mdx` - Famous Harare market
+- [ ] `destinations/victoria-falls-neighborhoods.mdx` - Where to stay/eat
+
+---
+
+## 8. Cultural Sites (Medium Priority)
+
+### Traditional Villages
+- [ ] `culture/traditional-villages.mdx` - Overview of cultural villages
+- [ ] `culture/monde-village.mdx` - Victoria Falls area
+- [ ] `culture/chikato-village.mdx` - Great Zimbabwe area
+- [ ] `culture/ngamo-village.mdx` - Hwange area
+
+### Crafts & Markets
+- [ ] `culture/mbare-musika.mdx` - Harare's largest market
+- [ ] `culture/bulawayo-craft-markets.mdx` - Craft shopping
+- [ ] `culture/victoria-falls-crafts.mdx` - Tourist crafts
+- [ ] `culture/tengenenge-sculpture.mdx` - Sculpture community
+
+### Sacred Sites
+- [ ] `culture/matonjeni-shrine.mdx` - Mwari cult center
+- [ ] `culture/njelele-shrine.mdx` - Sacred Matobo site
+- [ ] `culture/great-enclosure-ceremonies.mdx` - Great Zimbabwe rituals
+
+---
+
+## 9. Adventure Activities (Low Priority - Already Well Covered)
+
+### Specific Activity Guides
+- [ ] `adventure/bungee-jumping.mdx` - Victoria Falls bungee
+- [ ] `adventure/white-water-rafting-guide.mdx` - Detailed rafting
+- [ ] `adventure/gorge-swing.mdx` - Victoria Falls activity
+- [ ] `adventure/helicopter-tours.mdx` - Scenic flights
+- [ ] `adventure/microlight-flights.mdx` - Falls flights
+- [ ] `adventure/canoe-safaris.mdx` - Multi-day canoe trips
+- [ ] `adventure/walking-safaris.mdx` - Foot safari guide
+- [ ] `adventure/fishing-guide.mdx` - Tiger fish, trout
+- [ ] `adventure/horseback-safaris.mdx` - Horse riding options
+- [ ] `adventure/mountain-biking.mdx` - MTB routes
+
+---
+
+## 10. Practical Pages (Low Priority - Already Comprehensive)
+
+### Specialized Guides
+- [ ] `essentials/driving-guide.mdx` - Self-drive tips
+- [ ] `essentials/border-crossings.mdx` - All land borders
+- [ ] `essentials/car-rental.mdx` - Rental companies
+- [ ] `essentials/internal-flights.mdx` - Domestic aviation
+- [ ] `essentials/bus-travel.mdx` - Coach and bus options
+- [ ] `essentials/mobile-apps.mdx` - Useful apps for travelers
+- [ ] `essentials/photography-permits.mdx` - Where/when needed
+- [ ] `essentials/wifi-connectivity.mdx` - Internet access guide
+
+### Seasonal Guides
+- [ ] `planning/dry-season-guide.mdx` - May-October travel
+- [ ] `planning/green-season-guide.mdx` - November-April travel
+- [ ] `planning/shoulder-season.mdx` - Transitional periods
+
+---
+
+## 11. Themed Itineraries (Medium Priority)
+
+- [ ] `itineraries/unesco-circuit.mdx` - All 5 UNESCO sites
+- [ ] `itineraries/rock-art-trail.mdx` - Focus on rock art
+- [ ] `itineraries/birding-trail.mdx` - Top birding spots
+- [ ] `itineraries/photography-safari.mdx` - Best photo locations
+- [ ] `itineraries/walking-safari-circuit.mdx` - On-foot experiences
+- [ ] `itineraries/history-heritage.mdx` - Ruins and history focus
+- [ ] `itineraries/eastern-highlands-complete.mdx` - Full highlands tour
+- [ ] `itineraries/victoria-falls-extended.mdx` - 5-7 days at Falls
+- [ ] `itineraries/hwange-mana-combo.mdx` - Two-park safari
+- [ ] `itineraries/southern-circuit.mdx` - Gonarezhou, Matobo, GZ
+
+---
+
+## 12. Accommodation Guides (Medium Priority)
+
+### By Type
+- [ ] `accommodation/luxury-lodges.mdx` - Top-tier options
+- [ ] `accommodation/safari-camps.mdx` - Bush camp options
+- [ ] `accommodation/backpackers-hostels.mdx` - Budget options
+- [ ] `accommodation/camping-sites.mdx` - Campsite directory
+- [ ] `accommodation/self-catering.mdx` - Self-catering options
+- [ ] `accommodation/boutique-hotels.mdx` - Unique stays
+
+### By Destination
+- [ ] `accommodation/victoria-falls-hotels.mdx` - Complete VF guide
+- [ ] `accommodation/hwange-camps.mdx` - All Hwange options
+- [ ] `accommodation/harare-hotels.mdx` - City accommodation
+- [ ] `accommodation/eastern-highlands-stays.mdx` - Mountain lodges
+
+---
+
+## Priority Recommendations
+
+### Phase 1 (Immediate - High Impact)
+1. More rock art cave pages (Silozwane, Inanke, White Rhino)
+2. More waterfall pages (Nyangombe, Odzani)
+3. Individual national park pages (Chizarira, Zambezi NP)
+4. UNESCO circuit itinerary
+
+### Phase 2 (Short-term - Fill Gaps)
+1. Historic buildings (Railway Museum, Old Bulawayo)
+2. More geological sites (Epworth rocks, Great Dyke)
+3. Private game reserves (Malilangwe, Save Valley)
+4. More ruins (Regina, Inyanga structures)
+
+### Phase 3 (Medium-term - Depth)
+1. Themed itineraries
+2. Traditional villages
+3. Accommodation guides by type
+4. Activity-specific guides (bungee, rafting, fishing)
+
+### Phase 4 (Long-term - Completeness)
+1. Minor towns and cities
+2. Seasonal guides
+3. Specialized practical guides
+4. Township and neighborhood guides
+
+---
+
+## Content Sources & Research Notes
+
+### For Rock Art Pages
+- National Museums & Monuments of Zimbabwe archives
+- Rock Art Research Institute (RARI) publications
+- Harald Pager's Matobo rock art documentation
+- Nick Walker's research
+
+### For Historic Sites
+- National Archives of Zimbabwe
+- Bulawayo Public Library historical collection
+- Zimbabwe Heritage Trust publications
+
+### For Ruins
+- Peter Garlake's "Great Zimbabwe" and other publications
+- Thomas Huffman's archaeological research
+- National Museums excavation reports
+
+### For Wildlife/Parks
+- ZimParks official information
+- Wilderness Safaris research
+- African Wildlife Foundation reports
+- IUCN assessments
+
+---
+
+*Document created: December 2025*
+*Based on competitor analysis of ZimFieldGuide.com and current site structure*
+*Total potential additions: 150+ pages*

--- a/culture/art-and-music.mdx
+++ b/culture/art-and-music.mdx
@@ -37,6 +37,10 @@ canonical: 'https://travel-info.co.zw/culture/art-and-music'
 
 Zimbabwe boasts an extraordinarily rich artistic heritage that continues to evolve and gain international recognition. From the world-famous Shona stone sculptures to the soul-stirring sounds of mbira music, Zimbabwean artists have developed distinctive styles that reflect both ancient traditions and contemporary innovations.
 
+<Card title="Explore Zimbabwe's Ancient Rock Art" icon="palette" href="/rock-art">
+  Zimbabwe has one of the world's richest collections of San rock paintings dating back 13,000 years. Explore our detailed guides to Matobo's 3,000+ sites, the mysterious formlings of Mashonaland, and individual cave visits.
+</Card>
+
 ## Visual Arts
 
 ### Stone Sculpture

--- a/destinations/gonarezhou.mdx
+++ b/destinations/gonarezhou.mdx
@@ -620,6 +620,28 @@ This off-the-beaten-path destination rewards adventurous travelers with:
 
 ---
 
+## Explore Further
+
+<CardGroup cols={2}>
+  <Card title="Chilojo Cliffs" icon="mountain" href="/scenic/chilojo-cliffs">
+    Complete guide to Gonarezhou's iconic 180-meter red sandstone cliffs - viewpoints, photography tips, and cultural significance.
+  </Card>
+
+  <Card title="Great Zimbabwe" icon="landmark" href="/destinations/great-zimbabwe">
+    Combine with a visit to Africa's greatest ancient monument on your southern Zimbabwe circuit.
+  </Card>
+
+  <Card title="Scenic Viewpoints" icon="binoculars" href="/scenic">
+    Explore all of Zimbabwe's spectacular viewpoints and natural wonders.
+  </Card>
+
+  <Card title="UNESCO Heritage Sites" icon="globe" href="/heritage/unesco-world-heritage">
+    Discover Zimbabwe's five UNESCO World Heritage Sites including Great Zimbabwe nearby.
+  </Card>
+</CardGroup>
+
+---
+
 <Tip>
   **Gonarezhou Insider Tip**: The hidden gem of the park is the Tambohata Pan in the northern section, which is one of the few permanent water sources during the dry season. Arrive at dawn and position your vehicle patiently on the eastern side (for optimal light) to witness a parade of wildlife coming to drink throughout the morning. During peak dry season, you might see elephant herds, buffalo, various antelope species, and occasionally predators all within a few hours.
 </Tip>

--- a/destinations/matobo-hills.mdx
+++ b/destinations/matobo-hills.mdx
@@ -397,6 +397,36 @@ Combine your visit to Matobo with:
 
 * **Plumtree and Mphoengs**: Traditional villages with insight into rural Zimbabwean life
 
+---
+
+## Explore Further
+
+<CardGroup cols={2}>
+  <Card title="Rock Art Heritage" icon="palette" href="/rock-art/matobo-rock-art">
+    Detailed guide to Matobo's 3,000+ rock art sites, including the famous Nswatugi and Pomongwe caves, with visiting information and interpretation.
+  </Card>
+
+  <Card title="Nswatugi Cave" icon="mountain-sun" href="/rock-art/nswatugi-cave">
+    Visit one of Zimbabwe's most famous rock art sites featuring the iconic "swimming fish" panel and giraffes.
+  </Card>
+
+  <Card title="Pomongwe Cave" icon="image" href="/rock-art/pomongwe-cave">
+    Explore evidence of 100,000 years of human occupation with exceptional paintings and archaeological significance.
+  </Card>
+
+  <Card title="World's View Matobo" icon="binoculars" href="/scenic/worlds-view-matobo">
+    Complete guide to this iconic viewpoint and Cecil Rhodes' burial site atop the Matobo Hills.
+  </Card>
+
+  <Card title="Balancing Rocks" icon="scale-balanced" href="/geological/balancing-rocks">
+    Learn about Zimbabwe's famous geological formations, with the finest examples found here in Matobo.
+  </Card>
+
+  <Card title="Khami Ruins UNESCO Site" icon="landmark" href="/heritage/khami-ruins">
+    Discover the royal residence of the Torwa dynasty, Zimbabwe's lesser-known UNESCO World Heritage Site.
+  </Card>
+</CardGroup>
+
 ***
 
 <Info>

--- a/destinations/nyanga.mdx
+++ b/destinations/nyanga.mdx
@@ -413,16 +413,46 @@ Zimbabwe's premier mountain retreat, Nyanga offers a refreshing escape into mist
 
 <Card>
   **Combine Your Nyanga Visit With:**
-  
+
   * **Mutare** (105km): Zimbabwe's eastern gateway city
   * **Bvumba Mountains** (130km): Botanical gardens and misty forests
   * **Chimanimani** (250km): Wilderness hiking paradise
   * **Honde Valley** (30km): Tea estates and tropical fruits
   * **Ziwa Ruins** (Within park): Ancient stone settlements
   * **Juliasdale** (20km): Small village with craft shops
-  
+
   The entire Eastern Highlands region offers diverse attractions within easy driving distance.
 </Card>
+
+---
+
+## Explore Further
+
+<CardGroup cols={2}>
+  <Card title="Mtarazi Falls" icon="droplet" href="/scenic/mtarazi-falls">
+    Complete guide to Zimbabwe's highest waterfall at 762 meters - hiking trails, best times, and photography tips.
+  </Card>
+
+  <Card title="Pungwe Falls" icon="water" href="/scenic/pungwe-falls">
+    Visit this dramatic 240-meter cascade surrounded by misty montane forests near the Honde Valley.
+  </Card>
+
+  <Card title="World's View Nyanga" icon="binoculars" href="/scenic/worlds-view-nyanga">
+    Experience panoramic Eastern Highlands views stretching to Mozambique from this stunning viewpoint.
+  </Card>
+
+  <Card title="Ziwa Ruins" icon="landmark" href="/heritage/ziwa-ruins">
+    Explore the stone-walled settlements and agricultural terraces of Nyanga's ancient inhabitants.
+  </Card>
+
+  <Card title="Bridal Veil Falls" icon="heart" href="/scenic/bridal-veil-falls">
+    Discover this graceful waterfall near Chimanimani - perfect for swimming and picnics in the Eastern Highlands.
+  </Card>
+
+  <Card title="Eastern Highlands Waterfalls" icon="mountain" href="/scenic">
+    Browse all scenic viewpoints and waterfalls in Zimbabwe's Eastern Highlands region.
+  </Card>
+</CardGroup>
 
 ## Best Photo Spots
 

--- a/docs.json
+++ b/docs.json
@@ -100,6 +100,77 @@
   "navigation": {
     "tabs": [
       {
+        "tab": "Heritage & History",
+        "groups": [
+          {
+            "group": "UNESCO World Heritage",
+            "pages": [
+              "heritage/unesco-world-heritage",
+              "heritage/khami-ruins",
+              "destinations/great-zimbabwe",
+              "destinations/victoria-falls",
+              "destinations/mana-pools",
+              "destinations/matobo-hills"
+            ]
+          },
+          {
+            "group": "Ancient Ruins",
+            "pages": [
+              "heritage/naletale-ruins",
+              "heritage/dhlo-dhlo-ruins",
+              "heritage/ziwa-ruins",
+              "heritage/minor-ruins"
+            ]
+          },
+          {
+            "group": "Rock Art",
+            "pages": [
+              "rock-art/index",
+              "rock-art/matobo-rock-art",
+              "rock-art/nswatugi-cave",
+              "rock-art/pomongwe-cave",
+              "rock-art/chikupo-cave",
+              "rock-art/zombepata-cave",
+              "rock-art/mashonaland-sites",
+              "destinations/domboshava"
+            ]
+          },
+          {
+            "group": "Geological Wonders",
+            "pages": [
+              "geological/index",
+              "geological/balancing-rocks",
+              "geological/ngomakurira",
+              "destinations/chinhoyi-caves"
+            ]
+          },
+          {
+            "group": "Scenic Viewpoints",
+            "pages": [
+              "scenic/index",
+              "scenic/worlds-view-nyanga",
+              "scenic/worlds-view-matobo",
+              "scenic/chilojo-cliffs"
+            ]
+          },
+          {
+            "group": "Waterfalls",
+            "pages": [
+              "scenic/mtarazi-falls",
+              "scenic/pungwe-falls",
+              "scenic/bridal-veil-falls"
+            ]
+          },
+          {
+            "group": "Historic Sites",
+            "pages": [
+              "historic/index",
+              "historic/colonial-buildings"
+            ]
+          }
+        ]
+      },
+      {
         "tab": "Discover",
         "groups": [
           {

--- a/geological/balancing-rocks.mdx
+++ b/geological/balancing-rocks.mdx
@@ -1,6 +1,25 @@
 ---
 title: "Balancing Rocks of Zimbabwe"
-description: "Discover Zimbabwe's iconic balancing rocks - natural granite formations sculpted over billions of years, featured on the national currency"
+description: >-
+  Discover Zimbabwe's iconic balancing rocks - natural granite formations sculpted over billions of years, featured on the national currency
+'og:image': 'https://travel-info.co.zw/images/hero-light.svg'
+'og:site_name': "Zimbabwe Travel Information"
+'twitter:card': "summary_large_image"
+'twitter:site': '@zimbabwetravel'
+'twitter:creator': '@zimbabwetravel'
+robots: 'index, follow'
+author: "Zimbabwe Travel Information"
+keywords: >-
+  balancing rocks zimbabwe, epworth balancing rocks, matobo balancing rocks, domboshava rocks, zimbabwe currency rocks, granite formations africa
+'og:description': >-
+  Zimbabwe's iconic balancing rocks - natural granite sculptures featured on the national currency, billions of years old.
+'twitter:description': >-
+  Balancing rocks of Zimbabwe - iconic natural formations featured on the national currency.
+canonical: 'https://travel-info.co.zw/geological/balancing-rocks'
+'article:modified_time': '2025-12-30T00:00:00Z'
+'og:title': Balancing Rocks of Zimbabwe | Zimbabwe Travel Information
+'og:type': "article"
+'schema:type': "TouristDestination"
 ---
 
 # Balancing Rocks of Zimbabwe

--- a/geological/balancing-rocks.mdx
+++ b/geological/balancing-rocks.mdx
@@ -1,0 +1,329 @@
+---
+title: "Balancing Rocks of Zimbabwe"
+description: "Discover Zimbabwe's iconic balancing rocks - natural granite formations sculpted over billions of years, featured on the national currency"
+---
+
+# Balancing Rocks of Zimbabwe
+
+<img src="/images/geological/balancing-rocks-sunset.jpg" alt="Balancing rocks at sunset in Zimbabwe" />
+
+Zimbabwe's **balancing rocks** are among the country's most iconic natural features, so important they appear on Zimbabwean banknotes and coins. These seemingly impossible formations - massive boulders perched precariously on narrow bases - are the result of billions of years of geological processes.
+
+<Info>
+**National Symbol** - The Epworth Balancing Rocks appear on all Zimbabwean currency, making them one of the country's most recognized landmarks. They symbolize the balance and stability the nation aspires to.
+</Info>
+
+---
+
+## How Balancing Rocks Form
+
+### The Geology
+
+Zimbabwe sits on the **Zimbabwean Craton**, one of the oldest and most stable pieces of continental crust on Earth (over 2.5 billion years old). The balancing rocks formed through a process called **spheroidal weathering**:
+
+1. **Deep Underground Formation**
+   - Granite bedrock cools and contracts
+   - Fractures develop in rectangular patterns
+   - Water seeps into cracks
+
+2. **Chemical Weathering**
+   - Water reacts with feldspar in granite
+   - Edges and corners weather faster than faces
+   - Rectangular blocks become rounded boulders
+
+3. **Erosion Exposes Rocks**
+   - Overlying material erodes away
+   - Rounded boulders revealed at surface
+   - Softer material between boulders erodes
+
+4. **Balancing Creation**
+   - Differential weathering continues
+   - Softer rock beneath erodes faster
+   - Harder caps remain balanced on pedestals
+
+### Why They Don't Fall
+
+The balanced position results from:
+- **Low center of gravity** - Mass concentrated low
+- **Broad base of contact** - More stable than appears
+- **Interlocking surfaces** - Rough granite grips
+- **Millennia of stability** - Unstable rocks fell long ago
+
+---
+
+## Where to See Balancing Rocks
+
+### Epworth Balancing Rocks
+
+<img src="/images/geological/epworth-balancing-rocks-main.jpg" alt="Epworth Balancing Rocks" />
+
+The most famous formation, featured on currency:
+
+| | |
+|---|---|
+| **Location** | Epworth, 15 km SE of Harare |
+| **Access** | Easy - tar road, short walk |
+| **Entry** | Small community fee |
+| **Time Needed** | 30-60 minutes |
+| **Best Light** | Afternoon (matches currency image) |
+
+**Why Visit:**
+- The "money shot" - iconic Zimbabwe image
+- Easy half-day from Harare
+- Dramatic formations
+- Photography paradise
+
+**Tips:**
+- Afternoon sun matches banknote lighting
+- Local guides enhance the visit
+- Combine with Harare sightseeing
+- Support community tourism
+
+---
+
+### Matobo Hills
+
+The greatest concentration of balancing rocks in Zimbabwe:
+
+**Scale:**
+- Thousands of balanced formations
+- Spread over 3,000 km²
+- Combined with rock art
+- UNESCO World Heritage Site
+
+**Famous Formations:**
+| Name | Location | Features |
+|------|----------|----------|
+| **Mother and Child** | Near Maleme | Iconic pair |
+| **World's View** | Central Matobo | Rhodes burial site |
+| **Mjelele** | Various | Natural castles |
+
+[Explore Matobo Hills →](/destinations/matobo-hills)
+
+---
+
+### Domboshava
+
+Dramatic granite dome with balancing rocks:
+
+| | |
+|---|---|
+| **Location** | 30 km N of Harare |
+| **Combined With** | Rock art sites |
+| **Access** | Easy |
+| **Time** | 2-4 hours |
+
+**Features:**
+- "Whaleback" granite dome
+- Balancing boulders on slopes
+- Natural rock pools
+- Panoramic summit views
+
+[Explore Domboshava →](/destinations/domboshava)
+
+---
+
+### Ngomakurira
+
+Sacred mountain with spectacular formations:
+
+| | |
+|---|---|
+| **Location** | 40 km N of Harare |
+| **Difficulty** | Moderate-challenging hike |
+| **Features** | Summit boulders, drum rocks |
+| **Time** | 3-4 hours round trip |
+
+**Special Features:**
+- Massive summit boulders
+- Some rocks produce drum sounds when struck
+- Sacred site - approach with respect
+- Stunning views from top
+
+[Explore Ngomakurira →](/geological/ngomakurira)
+
+---
+
+### Lake Chivero Area
+
+Granite kopjes along lake shores:
+
+- Combined with wildlife viewing
+- Multiple balancing rock sites
+- Easy day trip from Harare
+- Boat access to some formations
+
+---
+
+### Mutoko Granite
+
+The Mutoko area is famous for:
+- Commercial granite quarries
+- Naturally balanced formations
+- High-quality stone
+- Less touristed
+
+---
+
+## The Science Behind the Beauty
+
+### Granite Characteristics
+
+| Property | Effect |
+|----------|--------|
+| **Hardness** | Resists erosion |
+| **Mineral composition** | Quartz, feldspar, mica |
+| **Fracture patterns** | Rectangular jointing |
+| **Color** | Grey, pink, varies with minerals |
+
+### Weathering Rates
+
+Different parts of the rock weather at different rates:
+- **Corners** - Three sides exposed, weather fastest
+- **Edges** - Two sides exposed, moderate weathering
+- **Faces** - One side exposed, slowest weathering
+
+This creates the rounded shapes from originally rectangular blocks.
+
+### Time Scales
+
+- **Granite formation:** 2.5+ billion years ago
+- **Spheroidal weathering:** Ongoing for millions of years
+- **Surface exposure:** Thousands to millions of years
+- **Balancing position:** Thousands of years stable
+
+---
+
+## Photography Guide
+
+### Best Conditions
+
+| Time | Light Quality | Best For |
+|------|---------------|----------|
+| **Sunrise** | Golden, dramatic | Silhouettes, drama |
+| **Morning** | Clear, directional | Details, textures |
+| **Midday** | Harsh, flat | Avoid if possible |
+| **Golden Hour** | Warm, dimensional | Classic shots |
+| **Sunset** | Red/orange glow | Most spectacular |
+| **Blue Hour** | Cool, ethereal | Moody images |
+
+### Composition Tips
+
+1. **Include Scale** - Person or object shows size
+2. **Silhouettes** - Against sunrise/sunset sky
+3. **Low Angles** - Emphasize height and drama
+4. **Details** - Texture and weathering patterns
+5. **Context** - Show surrounding landscape
+6. **Leading Lines** - Use rock patterns
+
+### Technical Settings
+
+| Subject | Aperture | Shutter | ISO |
+|---------|----------|---------|-----|
+| **Landscapes** | f/8-11 | Varies | Low |
+| **Details** | f/4-5.6 | Varies | Low |
+| **Silhouettes** | f/8 | Fast | Low |
+| **Blue hour** | f/2.8-4 | Slow | Medium |
+
+---
+
+## Cultural Significance
+
+### Traditional Beliefs
+
+Balancing rocks feature in Shona cosmology:
+- **Ancestor connection** - Some sites are sacred
+- **Rain-making** - Associated with ceremonies
+- **Territory markers** - Defined boundaries
+- **Spiritual power** - Concentration of forces
+
+### Modern Symbol
+
+- **National currency** - Pride and identity
+- **Tourism emblem** - Marketing icon
+- **Stability symbol** - Political metaphor
+- **Natural heritage** - Conservation focus
+
+---
+
+## Conservation
+
+### Threats
+
+| Threat | Risk Level | Impact |
+|--------|------------|--------|
+| **Vandalism** | Moderate | Graffiti, damage |
+| **Development** | High | Quarrying, building |
+| **Neglect** | Moderate | Lack of protection |
+| **Tourism** | Low | Minimal if managed |
+
+### Protection Status
+
+- **Epworth** - Not formally protected, community managed
+- **Matobo** - National Park + UNESCO World Heritage
+- **Domboshava** - National Monument
+- **Ngomakurira** - Community sacred site
+
+### How to Help
+
+- Visit and raise awareness
+- Support community tourism
+- Report vandalism
+- Advocate for protection
+- Share responsibly on social media
+
+---
+
+## Planning Your Visit
+
+### Day Trip Options from Harare
+
+| Site | Distance | Time | Difficulty |
+|------|----------|------|------------|
+| Epworth | 15 km | 1-2 hours | Easy |
+| Domboshava | 30 km | 2-4 hours | Easy-Moderate |
+| Ngomakurira | 40 km | 3-4 hours | Moderate |
+| Lake Chivero | 35 km | Half day | Easy |
+
+### Multi-Day Itinerary
+
+**Geology Tour (3 days):**
+- Day 1: Epworth + Domboshava
+- Day 2: Ngomakurira (full day hike)
+- Day 3: Lake Chivero + return
+
+**Extended (5+ days):**
+- Days 1-3: Harare area sites
+- Days 4-5: Matobo Hills
+- Day 6: Return
+
+### What to Bring
+
+- Camera with wide-angle lens
+- Sun protection
+- Water (no facilities at most sites)
+- Sturdy shoes for climbing
+- Binoculars for distant formations
+
+---
+
+## Frequently Asked Questions
+
+**Q: Will the rocks ever fall?**
+A: Unlikely in human timescales. They've been stable for thousands of years. The unstable ones already fell long ago.
+
+**Q: Can I climb on them?**
+A: At some sites, yes. At protected sites like Domboshava, stay on paths. Never climb at sacred sites without permission.
+
+**Q: Are they natural or human-made?**
+A: 100% natural. No human intervention in their formation.
+
+**Q: Why are they on the currency?**
+A: They symbolize strength, balance, and the endurance of Zimbabwe through difficulty.
+
+**Q: What's the best site for first-time visitors?**
+A: Epworth for accessibility, Domboshava for combined rock art, Matobo for quantity.
+
+<Card title="Billions of Years in Balance" icon="scale-balanced">
+These rocks have witnessed the evolution of life on Earth, the rise and fall of dinosaurs, and the emergence of humanity. When you touch a balancing rock, you're touching one of the oldest surfaces on the planet. Handle this privilege with awe.
+</Card>

--- a/geological/index.mdx
+++ b/geological/index.mdx
@@ -1,0 +1,285 @@
+---
+title: "Geological Wonders"
+description: "Discover Zimbabwe's remarkable geological features - balancing rocks, ancient caves, dramatic kopjes, and formations shaped over billions of years"
+---
+
+# Geological Wonders of Zimbabwe
+
+<img src="/images/geological/balancing-rocks-zimbabwe.jpg" alt="Balancing rocks formation Zimbabwe" />
+
+Zimbabwe sits on some of the oldest rocks on Earth - the ancient Zimbabwean Craton, formed over 2.5 billion years ago. This geological heritage has created a landscape of extraordinary natural sculptures, mysterious caves, and rock formations that seem to defy physics.
+
+<Info>
+**Ancient Landscape** - The granite kopjes and balancing rocks you see today have been shaped over millions of years through a process of spheroidal weathering, creating formations found nowhere else on Earth.
+</Info>
+
+---
+
+## Types of Geological Features
+
+### Balancing Rocks (Dwalas)
+
+Zimbabwe's most iconic geological features are the **balancing rocks** - massive boulders perched precariously on seemingly impossible bases. These formations are so important they appear on Zimbabwe's currency.
+
+**How They Form:**
+1. Granite bedrock is fractured by heat/cooling cycles
+2. Water seeps into cracks, causing chemical weathering
+3. Rounded boulders form underground (spheroidal weathering)
+4. Erosion exposes the boulders over millions of years
+5. Softer rock erodes away, leaving balanced formations
+
+**Famous Examples:**
+- **Epworth Balancing Rocks** - Featured on Zimbabwean currency
+- **Domboshava** - Dramatic formations near Harare
+- **Matobo Hills** - Thousands of balanced formations
+- **Ngomakurira** - Spectacular mountain of balanced rocks
+
+### Granite Kopjes
+
+**Kopjes** (from Afrikaans, pronounced "copy") are small hills or outcrops of rock. Zimbabwe's granite kopjes are:
+- Often dome-shaped
+- Covered with balanced boulders
+- Important wildlife habitats
+- Frequently sites of rock art
+- Sacred in many traditions
+
+### Caves and Rock Shelters
+
+Zimbabwe has numerous caves formed through:
+- Dissolution of limestone (Chinhoyi)
+- Weathering of granite (rock shelters)
+- Tectonic activity
+
+---
+
+## Featured Sites
+
+<CardGroup cols={2}>
+  <Card title="Chinhoyi Caves" icon="cave" href="/destinations/chinhoyi-caves">
+    Spectacular limestone caves with legendary "Sleeping Pool"
+  </Card>
+  <Card title="Domboshava" icon="mountain" href="/destinations/domboshava">
+    Granite formations, rock art, and panoramic views
+  </Card>
+  <Card title="Matobo Hills" icon="monument" href="/destinations/matobo-hills">
+    UNESCO site with thousands of balancing rocks
+  </Card>
+  <Card title="Ngomakurira" icon="gem" href="/geological/ngomakurira">
+    Sacred mountain with extraordinary rock formations
+  </Card>
+</CardGroup>
+
+---
+
+## Chinhoyi Caves National Park
+
+<img src="/images/geological/chinhoyi-caves-pool.jpg" alt="Chinhoyi Caves blue pool" />
+
+Zimbabwe's most famous cave system features the legendary **Sleeping Pool** (Chirorodziva) - a collapsed cave chamber filled with impossibly blue water.
+
+### What to See
+
+| Feature | Description |
+|---------|-------------|
+| **Sleeping Pool** | Crystal-clear blue pool, 90m deep |
+| **Dark Cave** | Extensive cavern system |
+| **Bat Cave** | Home to thousands of bats |
+| **Main Cave** | Easy access viewing platform |
+
+### The Sleeping Pool
+
+The Sleeping Pool gets its name from a legend that the pool has no bottom and anything thrown in "sleeps" forever. In reality, it's:
+- Approximately 90 meters deep
+- Filled with crystal-clear blue water
+- Connected to underground chambers
+- Popular with scuba divers (permit required)
+
+### Practical Information
+
+| | |
+|---|---|
+| **Location** | 135 km northwest of Harare |
+| **Entry Fee** | $10 USD |
+| **Hours** | 8:00 AM - 5:00 PM |
+| **Time Needed** | 1-2 hours |
+| **Facilities** | Parking, toilets, picnic area |
+
+[Full Guide to Chinhoyi Caves →](/destinations/chinhoyi-caves)
+
+---
+
+## Epworth Balancing Rocks
+
+<img src="/images/geological/epworth-balancing-rocks.jpg" alt="Epworth Balancing Rocks" />
+
+The most famous balancing rocks in Zimbabwe, **featured on the country's banknotes and coins**. Located just southeast of Harare in the Epworth area.
+
+### Why They're Famous
+
+- Featured on all Zimbabwean currency
+- Photographed as a national symbol
+- Easily accessible from Harare
+- Particularly dramatic formations
+
+### Visiting Epworth
+
+| | |
+|---|---|
+| **Location** | Epworth, 15 km southeast of Harare |
+| **Entry Fee** | Small fee to local community |
+| **Best Time** | Early morning or late afternoon |
+| **Time Needed** | 30 minutes - 1 hour |
+
+<Tip>
+For the iconic "currency shot," visit in the late afternoon when the sun illuminates the rocks from the west, matching the image on Zimbabwean notes.
+</Tip>
+
+---
+
+## Ngomakurira Mountain
+
+<img src="/images/geological/ngomakurira.jpg" alt="Ngomakurira mountain balancing rocks" />
+
+**Ngomakurira** ("place of drums") is a sacred mountain approximately 40 km north of Harare, featuring some of Zimbabwe's most spectacular rock formations and important rock art sites.
+
+### Features
+
+| Feature | Description |
+|---------|-------------|
+| **Summit Rocks** | Massive balanced boulders at the peak |
+| **Rock Art Sites** | San paintings in shelters |
+| **Cave Systems** | Natural shelters and caves |
+| **Panoramic Views** | 360° views from summit |
+
+### Hiking Ngomakurira
+
+**Trail Information:**
+- **Distance:** ~5 km round trip
+- **Elevation Gain:** ~300 meters
+- **Difficulty:** Moderate to challenging
+- **Time:** 3-4 hours
+
+**What to Bring:**
+- Sturdy hiking shoes
+- 2+ liters of water
+- Sun protection
+- Camera
+- Snacks
+
+### Spiritual Significance
+
+The name means "place of drums" because:
+- The rocks produce drum-like sounds when tapped
+- Used for traditional ceremonies
+- Still considered sacred by local communities
+- Please show respect when visiting
+
+---
+
+## Balancing Rocks of Matobo
+
+The Matobo Hills contain **thousands of balancing rock formations** spread across 3,000 km² of dramatic granite landscape.
+
+### Why Matobo is Special
+
+- **Scale** - The largest concentration of balanced rocks in Africa
+- **Variety** - From small balanced pebbles to massive boulders
+- **Age** - Formed over 2 billion years
+- **Diversity** - Combined with rock art and wildlife
+
+### Must-See Formations
+
+| Location | Feature |
+|----------|---------|
+| **Mother and Child** | Iconic formation near Maleme Dam |
+| **World's View** | Dramatic kopje with Cecil Rhodes' grave |
+| **Nswatugi Area** | Rocks and rock art combined |
+| **Mjelele** | Spectacular natural castle |
+
+[Explore Matobo Hills →](/destinations/matobo-hills)
+
+---
+
+## Other Notable Sites
+
+### Lake Chivero Rock Formations
+
+The shores of Lake Chivero (30 km from Harare) feature:
+- Granite kopjes rising from the water
+- Balanced rocks along the shore
+- Combined wildlife viewing opportunities
+- Easy day trip from Harare
+
+### Mutoko Granite Quarries
+
+While commercial, the quarries near Mutoko show:
+- How granite formations develop
+- Local stone-cutting traditions
+- The quality of Zimbabwean granite
+- (Not a tourist site per se, but geologically interesting)
+
+### Great Dyke
+
+A 550 km geological formation running north-south:
+- Visible from satellite images
+- Contains chromium and platinum deposits
+- Creates distinctive landscape features
+- One of Earth's major geological features
+
+---
+
+## Geological Timeline
+
+| Era | Years Ago | Events |
+|-----|-----------|--------|
+| **Archaean** | 3.5-2.5 billion | Formation of granite cratons |
+| **Proterozoic** | 2.5 billion-540 million | Great Dyke formation, metamorphism |
+| **Paleozoic** | 540-250 million | Sedimentary deposits |
+| **Mesozoic** | 250-66 million | Karoo sediments, coal formation |
+| **Cenozoic** | 66 million-present | Erosion, kopje formation, caves |
+
+---
+
+## Photography Tips
+
+### Best Times
+
+- **Golden hour** (sunrise/sunset) for dramatic lighting
+- **Overcast days** for even lighting without harsh shadows
+- **Dry season** for clearer skies
+
+### Techniques
+
+| Subject | Tip |
+|---------|-----|
+| **Balancing rocks** | Include a person for scale |
+| **Caves** | Use wide-angle lens, tripod |
+| **Kopjes** | Multiple exposures for sky/rock detail |
+| **Details** | Macro lens for rock textures |
+
+---
+
+## Geology Tourism Tips
+
+### Best Sites for...
+
+| Interest | Recommended Site |
+|----------|------------------|
+| **Photography** | Matobo Hills, Epworth |
+| **Caves** | Chinhoyi Caves |
+| **Hiking** | Ngomakurira, Domboshava |
+| **Accessibility** | Epworth, Chinhoyi |
+| **Combined wildlife** | Matobo Hills |
+| **Combined rock art** | Domboshava, Matobo |
+
+### What to Know
+
+- Many sites are on communal land - ask permission
+- Local guides enhance the experience
+- Respect sacred sites
+- Some formations are fragile - don't climb without permission
+- Entry fees support conservation
+
+<Card title="Billions of Years in Stone" icon="hourglass">
+When you visit Zimbabwe's geological wonders, you're seeing formations that began taking shape when the Earth was less than half its current age. These ancient landscapes connect us to the planet's deepest history.
+</Card>

--- a/geological/index.mdx
+++ b/geological/index.mdx
@@ -1,6 +1,25 @@
 ---
 title: "Geological Wonders"
-description: "Discover Zimbabwe's remarkable geological features - balancing rocks, ancient caves, dramatic kopjes, and formations shaped over billions of years"
+description: >-
+  Discover Zimbabwe's remarkable geological features - balancing rocks, ancient caves, dramatic kopjes, and formations shaped over billions of years
+'og:image': 'https://travel-info.co.zw/images/hero-light.svg'
+'og:site_name': "Zimbabwe Travel Information"
+'twitter:card': "summary_large_image"
+'twitter:site': '@zimbabwetravel'
+'twitter:creator': '@zimbabwetravel'
+robots: 'index, follow'
+author: "Zimbabwe Travel Information"
+keywords: >-
+  zimbabwe geology, balancing rocks zimbabwe, chinhoyi caves, granite kopjes, matobo rocks, geological features africa, ancient rocks zimbabwe
+'og:description': >-
+  Zimbabwe's geological wonders - balancing rocks, ancient caves, and dramatic kopjes shaped over billions of years.
+'twitter:description': >-
+  Discover Zimbabwe's remarkable geology - balancing rocks, caves, and formations billions of years old.
+canonical: 'https://travel-info.co.zw/geological/index'
+'article:modified_time': '2025-12-30T00:00:00Z'
+'og:title': Geological Wonders of Zimbabwe | Zimbabwe Travel Information
+'og:type': "article"
+'schema:type': "TouristDestination"
 ---
 
 # Geological Wonders of Zimbabwe

--- a/geological/ngomakurira.mdx
+++ b/geological/ngomakurira.mdx
@@ -1,6 +1,25 @@
 ---
 title: "Ngomakurira Mountain"
-description: "Hike the sacred Ngomakurira Mountain - 'the place of drums' with spectacular balancing rocks, ancient rock art, and spiritual significance near Harare"
+description: >-
+  Hike the sacred Ngomakurira Mountain - 'the place of drums' with spectacular balancing rocks, ancient rock art, and spiritual significance near Harare
+'og:image': 'https://travel-info.co.zw/images/hero-light.svg'
+'og:site_name': "Zimbabwe Travel Information"
+'twitter:card': "summary_large_image"
+'twitter:site': '@zimbabwetravel'
+'twitter:creator': '@zimbabwetravel'
+robots: 'index, follow'
+author: "Zimbabwe Travel Information"
+keywords: >-
+  ngomakurira, hiking harare, sacred mountain zimbabwe, drum rocks, balancing rocks harare, day hike zimbabwe, rock art harare
+'og:description': >-
+  Ngomakurira Mountain near Harare - sacred 'place of drums' with spectacular balancing rocks and ancient rock art.
+'twitter:description': >-
+  Ngomakurira - sacred mountain hike near Harare with drum rocks, balancing formations, and rock art.
+canonical: 'https://travel-info.co.zw/geological/ngomakurira'
+'article:modified_time': '2025-12-30T00:00:00Z'
+'og:title': Ngomakurira Mountain | Zimbabwe Travel Information
+'og:type': "article"
+'schema:type': "TouristDestination"
 ---
 
 # Ngomakurira Mountain

--- a/geological/ngomakurira.mdx
+++ b/geological/ngomakurira.mdx
@@ -1,0 +1,323 @@
+---
+title: "Ngomakurira Mountain"
+description: "Hike the sacred Ngomakurira Mountain - 'the place of drums' with spectacular balancing rocks, ancient rock art, and spiritual significance near Harare"
+---
+
+# Ngomakurira Mountain
+
+<img src="/images/geological/ngomakurira-mountain.jpg" alt="Ngomakurira Mountain balancing rocks" />
+
+**Ngomakurira** (meaning "place of drums" in Shona) is a sacred mountain approximately 40 km north of Harare, renowned for its extraordinary granite formations, ancient rock art, and deep spiritual significance. The mountain rises dramatically from the surrounding landscape, topped with massive balancing boulders that resemble a natural fortress.
+
+<Info>
+**Sacred Mountain** - Ngomakurira remains an active sacred site for local communities. When certain rocks are struck, they produce drum-like sounds, giving the mountain its name and contributing to its spiritual importance.
+</Info>
+
+---
+
+## Quick Facts
+
+| | |
+|---|---|
+| **Location** | 40 km north of Harare, Mashonaland East |
+| **Altitude** | ~1,500 meters at summit |
+| **Hike Distance** | ~5 km round trip |
+| **Difficulty** | Moderate to challenging |
+| **Time Required** | 3-4 hours |
+| **Best For** | Hikers, photographers, spiritual seekers |
+| **Entry Fee** | ~$5 USD (community fee) |
+
+---
+
+## Why Visit Ngomakurira
+
+### The Balancing Rocks
+
+Ngomakurira features some of the most spectacular balancing rock formations in Zimbabwe:
+
+- **Summit Boulders** - Massive rocks perched impossibly at the peak
+- **Natural Archways** - Rocks creating tunnels and passages
+- **Cave Formations** - Shelters and overhangs
+- **Dramatic Silhouettes** - Perfect for photography
+
+### Ancient Rock Art
+
+Multiple rock shelters contain San (Bushman) paintings:
+- Human and animal figures
+- Geometric patterns
+- Well-preserved despite exposure
+- Multiple sites throughout the mountain
+
+### Spiritual Significance
+
+The mountain holds deep meaning for local Shona communities:
+- Used for traditional ceremonies
+- Rocks produce drum sounds when struck
+- Associated with ancestral spirits
+- Rain-making rituals historically performed
+
+### Panoramic Views
+
+From the summit:
+- 360-degree views over Mashonaland
+- Harare visible on clear days
+- Surrounding granite kopjes
+- Spectacular sunrise/sunset vistas
+
+---
+
+## The Hike
+
+### Trail Overview
+
+| Stage | Distance | Time | Description |
+|-------|----------|------|-------------|
+| **Trailhead to Base** | 1 km | 20 min | Gentle path through bush |
+| **Base to Mid-Point** | 1 km | 40 min | Steeper climb, rock scrambling begins |
+| **Mid-Point to Summit** | 0.5 km | 40 min | Challenging scramble, some exposed sections |
+| **Summit Exploration** | - | 30-60 min | Multiple rock formations to explore |
+| **Return** | 2.5 km | 1.5 hours | Same route back |
+
+### Difficulty Assessment
+
+| Factor | Rating |
+|--------|--------|
+| **Overall Difficulty** | Moderate-Challenging |
+| **Fitness Required** | Good |
+| **Scrambling** | Yes, significant |
+| **Exposure** | Some exposed sections |
+| **Navigation** | Clear but no markers |
+| **Shade** | Limited |
+
+### What to Expect
+
+**Lower Section:**
+- Well-defined path
+- Gentle gradient
+- Bush and woodland
+- Some rock art sites
+
+**Middle Section:**
+- Gradient increases
+- Path becomes rougher
+- Rock scrambling begins
+- More challenging footing
+
+**Upper Section:**
+- Significant scrambling
+- Use hands in places
+- Some exposed areas
+- Spectacular views open up
+
+**Summit:**
+- Massive balancing boulders
+- Cave-like passages
+- Multiple viewpoints
+- Space to rest and explore
+
+---
+
+## Practical Information
+
+### Getting There
+
+**From Harare (40 km):**
+1. Head north on Borrowdale Road
+2. Continue past Domboshava
+3. Turn right at Ngomakurira signpost
+4. Follow dirt road to community parking area
+5. Park and register with local guides
+
+**GPS Coordinates:** -17.5833° S, 31.1667° E
+
+<Tip>
+The final section of road can be rough - a sturdy vehicle is recommended, especially in the wet season.
+</Tip>
+
+### Entry and Guides
+
+| | |
+|---|---|
+| **Entry Fee** | ~$5 USD (community charge) |
+| **Guide Fee** | $10-15 USD (recommended) |
+| **Registration** | Required at trailhead |
+| **Best Days** | Weekdays less crowded |
+
+**Why hire a guide:**
+- Know the best rock art locations
+- Explain cultural significance
+- Ensure safety on scrambles
+- Support local community
+- Navigate the route
+
+### What to Bring
+
+**Essential:**
+- Sturdy hiking boots (ankle support)
+- 2+ liters of water (no sources on mountain)
+- Sun protection (hat, sunscreen)
+- Light snacks/energy food
+- Camera
+
+**Recommended:**
+- Hiking poles (helpful on descent)
+- Light rain jacket
+- Binoculars
+- First aid basics
+- Warm layer (summit can be windy)
+
+### Best Time to Visit
+
+| Season | Conditions |
+|--------|------------|
+| **Dry (May-Oct)** | Best for hiking, clear skies, easier paths |
+| **Early Wet (Nov-Dec)** | Greener scenery, afternoon storms possible |
+| **Late Wet (Jan-Apr)** | Paths can be slippery, dramatic clouds |
+
+**Time of Day:**
+- **Sunrise hike** - Spectacular light, cooler
+- **Morning start** - Avoid afternoon heat
+- **Sunset summit** - Beautiful but requires torch for descent
+
+---
+
+## The Drum Rocks
+
+The mountain's name comes from rocks that produce drum-like sounds when struck:
+
+### How It Works
+
+- Certain rocks are "lithophonic" (produce musical tones)
+- When struck with a smaller rock, they ring like drums
+- Different rocks produce different tones
+- Used in traditional ceremonies
+
+### Cultural Significance
+
+- Communication method historically
+- Associated with calling ancestors
+- Part of rain-making rituals
+- Still used in ceremonies today
+
+<Warning>
+The drum rocks are sacred. Ask your guide before striking them, and respect any areas that are off-limits due to ongoing ceremonies.
+</Warning>
+
+---
+
+## Rock Art Sites
+
+Ngomakurira contains several rock art sites in caves and overhangs:
+
+### What You'll See
+
+- **Animal figures** - Kudu, eland, other antelope
+- **Human figures** - Hunting scenes, dancing
+- **Geometric patterns** - Dots, lines, curves
+- **Handprints** - In some shelters
+
+### Viewing Tips
+
+- Your guide knows the locations
+- Best light mid-morning
+- No touching (oils damage pigments)
+- Photography without flash
+
+---
+
+## Photography
+
+Ngomakurira offers exceptional photography opportunities:
+
+### Best Shots
+
+| Subject | Best Time | Tips |
+|---------|-----------|------|
+| **Sunrise silhouettes** | Dawn | Arrive early, tripod essential |
+| **Rock formations** | Golden hour | Side lighting shows texture |
+| **Panoramic views** | Anytime clear | Wide angle lens |
+| **Rock art** | Mid-morning | No flash, use tripod |
+| **Dramatic clouds** | Wet season | Polarizing filter |
+
+### Recommended Gear
+
+- Wide-angle lens (16-35mm)
+- Telephoto for details
+- Tripod for low light
+- Polarizing filter
+- Lens cloth (dust and humidity)
+
+---
+
+## Safety
+
+### Important Considerations
+
+- **Scrambling required** - Comfortable with rock climbing
+- **Exposed sections** - Take care near edges
+- **Weather changes** - Lightning dangerous on summit
+- **Heat/sun** - Limited shade, carry water
+- **No facilities** - No toilets on mountain
+
+### Safety Tips
+
+1. **Don't hike alone** - Use a guide or group
+2. **Start early** - Avoid afternoon heat/storms
+3. **Turn back if needed** - No shame in stopping
+4. **Watch your step** - Granite can be slippery
+5. **Carry a phone** - For emergencies
+
+---
+
+## Combining with Other Sites
+
+### Ngomakurira + Domboshava (Full Day)
+
+**Morning:** Ngomakurira hike (3-4 hours)
+**Midday:** Lunch in Borrowdale
+**Afternoon:** Domboshava (2 hours)
+
+### Two-Day Geology Tour from Harare
+
+**Day 1:**
+- Morning: Epworth Balancing Rocks
+- Afternoon: Lake Chivero area
+
+**Day 2:**
+- Full day: Ngomakurira hike
+
+---
+
+## Nearby Attractions
+
+| Attraction | Distance | Description |
+|------------|----------|-------------|
+| Domboshava | 15 km | Rock art, easier climb |
+| Epworth Balancing Rocks | 50 km | Famous formations |
+| Lake Chivero | 55 km | Wildlife, boating |
+| Mazowe Dam | 20 km | Scenic citrus area |
+| Harare | 40 km | Capital city |
+
+---
+
+## Respect and Etiquette
+
+Ngomakurira is a living sacred site:
+
+**Do:**
+- Register with local community
+- Hire a local guide
+- Ask before photographing people
+- Respect quiet zones
+- Support the community
+
+**Don't:**
+- Strike drum rocks without permission
+- Touch rock art
+- Leave any rubbish
+- Play loud music
+- Disturb ceremonies if occurring
+
+<Card title="Sacred Landscape" icon="mountain-sun">
+Ngomakurira is more than a hike - it's an encounter with a landscape that has been sacred for generations. The balancing rocks, the drum sounds, and the rock art all speak to a deep human connection with this place. Approach with respect, and you'll be rewarded with an unforgettable experience.
+</Card>

--- a/heritage/dhlo-dhlo-ruins.mdx
+++ b/heritage/dhlo-dhlo-ruins.mdx
@@ -1,6 +1,25 @@
 ---
 title: "Danangombe (Dhlo Dhlo) Ruins"
-description: "Explore Danangombe, also known as Dhlo Dhlo - the last capital of the powerful Rozvi Empire in pre-colonial Zimbabwe"
+description: >-
+  Explore Danangombe, also known as Dhlo Dhlo - the last capital of the powerful Rozvi Empire in pre-colonial Zimbabwe
+'og:image': 'https://travel-info.co.zw/images/hero-light.svg'
+'og:site_name': "Zimbabwe Travel Information"
+'twitter:card': "summary_large_image"
+'twitter:site': '@zimbabwetravel'
+'twitter:creator': '@zimbabwetravel'
+robots: 'index, follow'
+author: "Zimbabwe Travel Information"
+keywords: >-
+  danangombe ruins, dhlo dhlo, rozvi empire, changamire dynasty, zimbabwe ruins, midlands ruins, stone ruins africa, pre-colonial zimbabwe
+'og:description': >-
+  Visit Danangombe (Dhlo Dhlo) - the last capital of the Rozvi Empire and one of Zimbabwe's largest stone-built settlements.
+'twitter:description': >-
+  Danangombe (Dhlo Dhlo) Ruins - the last capital of Zimbabwe's powerful Rozvi Empire.
+canonical: 'https://travel-info.co.zw/heritage/dhlo-dhlo-ruins'
+'article:modified_time': '2025-12-30T00:00:00Z'
+'og:title': Danangombe (Dhlo Dhlo) Ruins | Zimbabwe Travel Information
+'og:type': "article"
+'schema:type': "TouristDestination"
 ---
 
 # Danangombe (Dhlo Dhlo) Ruins

--- a/heritage/dhlo-dhlo-ruins.mdx
+++ b/heritage/dhlo-dhlo-ruins.mdx
@@ -1,0 +1,237 @@
+---
+title: "Danangombe (Dhlo Dhlo) Ruins"
+description: "Explore Danangombe, also known as Dhlo Dhlo - the last capital of the powerful Rozvi Empire in pre-colonial Zimbabwe"
+---
+
+# Danangombe (Dhlo Dhlo) Ruins
+
+<img src="/images/heritage/dhlo-dhlo-ruins.jpg" alt="Danangombe ruins stone walls" />
+
+**Danangombe**, historically known as **Dhlo Dhlo**, was the last capital of the Rozvi Empire and one of the largest stone-built settlements in Zimbabwe. Located in the Midlands Province, this sprawling site represents the final flowering of Zimbabwe's great stone-building tradition before the upheavals of the 19th century.
+
+<Info>
+**UNESCO Tentative List** - Danangombe has been on Zimbabwe's UNESCO World Heritage Tentative List since 1997, recognized for its historical significance as the Rozvi capital.
+</Info>
+
+---
+
+## Quick Facts
+
+| | |
+|---|---|
+| **Location** | Near Shangani, Midlands Province |
+| **Period** | c. 1683-1830 AD |
+| **Kingdom** | Rozvi Empire (Changamire dynasty) |
+| **Also Known As** | Dhlo Dhlo, Dlo Dlo |
+| **Status** | National Monument, UNESCO Tentative List |
+| **Size** | One of the largest stone ruin complexes |
+| **Entry Fee** | $5 USD |
+
+---
+
+## Historical Significance
+
+### Capital of the Rozvi
+
+Danangombe became the capital of the Rozvi Empire after Changamire Dombo destroyed Khami around 1683. From here, the Rozvi controlled:
+
+- Much of the Zimbabwe plateau
+- Important gold-producing regions
+- Trade routes to the coast
+- Tributary states and chieftaincies
+
+### The Changamire Dynasty
+
+The Rozvi emperors, known by the dynastic title **Changamire**, ruled from Danangombe for approximately 150 years. The empire was renowned for:
+
+- **Military Power** - The Rozvi army was feared throughout the region
+- **Cattle Wealth** - Vast herds were a measure of royal power
+- **Stone Architecture** - Continued the building traditions of Great Zimbabwe
+- **Religious Authority** - Controlled the Mwari oracle at Matobo
+
+### The Fall of the Rozvi
+
+The Rozvi Empire met its end during the Mfecane period (1820s-1830s) when:
+1. Nguni groups fleeing Shaka Zulu's wars invaded
+2. Nxaba's Nguni attacked Rozvi settlements
+3. Mzilikazi's Ndebele forces completed the conquest
+4. The last Changamire was killed, ending the dynasty
+
+---
+
+## What to See
+
+### The Main Enclosure
+
+The royal residence features:
+- Massive stone walls up to 6 meters high
+- Decorated sections with geometric patterns
+- Multiple entrances with narrow passages
+- Central court area
+
+### Platform Complexes
+
+Like Khami, Danangombe features terraced platforms built on natural kopjes:
+- **Upper Platform** - Probable royal quarters
+- **Lower Platforms** - Administrative and residential areas
+- Stone-lined drains and passages
+
+### Wall Decorations
+
+While not as elaborate as Naletale, Danangombe displays:
+- Chevron patterns
+- Checkered designs
+- Herringbone sections
+- Stone coursing techniques
+
+### Artifact Evidence
+
+Archaeological excavations have recovered:
+- Portuguese trade beads
+- Chinese porcelain fragments
+- Gold artifacts
+- Iron implements
+- Cattle bones (indicating wealth)
+
+---
+
+## The Rozvi Legacy
+
+### Building Techniques
+
+The Rozvi perfected techniques inherited from Great Zimbabwe:
+
+| Innovation | Description |
+|------------|-------------|
+| **Terracing** | Building on natural hills rather than flat ground |
+| **Decoration** | Elaborate wall patterns as artistic expression |
+| **Drainage** | Sophisticated water management systems |
+| **Integration** | Incorporating natural rock into structures |
+
+### Cultural Continuity
+
+The Rozvi saw themselves as inheritors of the Great Zimbabwe tradition:
+- Used the same dry-stone building methods
+- Continued the Zimbabwe Bird tradition
+- Maintained trade networks
+- Preserved religious practices
+
+---
+
+## Visiting Danangombe
+
+### Getting There
+
+**From Gweru (90 km):**
+1. Take the Bulawayo road west
+2. Continue past Shangani
+3. Follow signs to Danangombe/Dhlo Dhlo
+4. Last section is on gravel road
+
+**From Bulawayo (140 km):**
+1. Take the Harare road east
+2. Before reaching Gweru, watch for signposts
+3. Turn onto the Danangombe access road
+
+<Warning>
+Road conditions vary seasonally. During the rainy season (November-March), access may be difficult. Check locally and consider a 4x4 vehicle.
+</Warning>
+
+**GPS Coordinates:** -19.4156° S, 29.0542° E
+
+### Practical Information
+
+| | |
+|---|---|
+| **Entry Fee** | $5 USD |
+| **Hours** | Daylight hours |
+| **Facilities** | Very basic - bring supplies |
+| **Accommodation** | None on-site (Gweru or Shangani) |
+| **Time Needed** | 2-3 hours |
+
+### Visitor Tips
+
+- **Wear sturdy shoes** - terrain is uneven
+- **Bring water** - no facilities on site
+- **Allow time to explore** - the site is extensive
+- **Consider a guide** - ask in Shangani village
+- **Morning visit** - better light for photography
+
+---
+
+## Combining Sites
+
+### Rozvi Heritage Route
+
+Experience the full story of the Rozvi Empire:
+
+**Day 1: Arrival in Bulawayo**
+- Evening: Explore Bulawayo
+
+**Day 2: Khami Ruins**
+- Morning: Khami (Torwa capital, pre-Rozvi)
+- Afternoon: Drive to Gweru area
+
+**Day 3: Rozvi Capitals**
+- Morning: Naletale Ruins
+- Afternoon: Danangombe (Dhlo Dhlo)
+
+**Day 4: Continue**
+- Option A: East to Great Zimbabwe
+- Option B: Return to Bulawayo for Matobo Hills
+
+---
+
+## Understanding the Name
+
+The site has been known by different names:
+
+- **Danangombe** - The official NMMZ name, a local place name
+- **Dhlo Dhlo** - Colonial-era name, derived from Ndebele
+- **Dlo Dlo** - Variant spelling
+
+Both names are used, but "Danangombe" is preferred in academic and official contexts, while "Dhlo Dhlo" remains common in tourist literature.
+
+---
+
+## Comparison with Other Sites
+
+| Site | Capital Of | Period | Size | Preservation |
+|------|-----------|--------|------|--------------|
+| Great Zimbabwe | Zimbabwe Kingdom | 1100-1450 | Largest | Good |
+| Khami | Torwa State | 1450-1683 | Large | Good |
+| Naletale | Rozvi regional | 1650-1750 | Medium | Good |
+| **Danangombe** | Rozvi Empire | 1683-1830 | Very Large | Fair |
+
+---
+
+## Conservation
+
+Danangombe is a protected National Monument, but faces challenges:
+
+- **Remote location** limits monitoring
+- **Vegetation growth** threatens walls
+- **Limited visitor infrastructure**
+- **Weather erosion** of stone structures
+
+**Help preserve this site:**
+- Stay on marked paths
+- Don't climb on walls
+- Report damage to authorities
+- Support NMMZ conservation efforts
+
+---
+
+## Nearby Attractions
+
+| Attraction | Distance | Description |
+|------------|----------|-------------|
+| Naletale Ruins | 40 km | Finest decorated walls in Zimbabwe |
+| Gweru | 90 km | Provincial capital |
+| Khami Ruins | 140 km | UNESCO World Heritage Site |
+| Antelope Park | 110 km | Wildlife experiences |
+| Great Zimbabwe | 210 km | Zimbabwe's most famous ruins |
+
+<Card title="The Last Capital" icon="crown">
+Danangombe represents the end of an era - the final capital of a dynasty that traced its legitimacy back to Great Zimbabwe itself. Walking among these ruins, you're standing where the last Rozvi emperors ruled over much of what is now Zimbabwe.
+</Card>

--- a/heritage/khami-ruins.mdx
+++ b/heritage/khami-ruins.mdx
@@ -1,0 +1,228 @@
+---
+title: "Khami Ruins"
+description: "Explore Khami Ruins, Zimbabwe's second UNESCO World Heritage Site - the ancient capital of the Torwa dynasty with distinctive terraced architecture"
+---
+
+# Khami Ruins
+
+<img src="/images/heritage/khami-ruins-main.jpg" alt="Khami Ruins terraced walls" />
+
+**Khami Ruins** (also spelled Khame or Kame) is a UNESCO World Heritage Site located 22 kilometers west of Bulawayo. As the second largest stone-built monument in Zimbabwe after Great Zimbabwe, Khami was the capital of the Torwa Kingdom and represents an important phase in Zimbabwean history (1450-1683 AD).
+
+<Info>
+**UNESCO World Heritage Site** - Inscribed in 1986 for its outstanding universal value as an example of innovative dry-stone walling techniques and its evidence of extensive international trade networks.
+</Info>
+
+---
+
+## Quick Facts
+
+| | |
+|---|---|
+| **Location** | 22 km west of Bulawayo, Matabeleland North |
+| **UNESCO Status** | World Heritage Site (1986) |
+| **Period** | c. 1450-1683 AD |
+| **Kingdom** | Torwa Dynasty (Butua State) |
+| **Size** | Approximately 2 km² |
+| **Entry Fee** | $10 USD |
+| **Hours** | 8:00 AM - 5:00 PM daily |
+
+---
+
+## History
+
+### Rise of the Torwa Dynasty
+
+After the decline of Great Zimbabwe around 1450 AD, power shifted westward. The Torwa dynasty established Khami as the capital of what became known as the Butua State. Unlike Great Zimbabwe which was built on flat ground, Khami's builders chose to construct on natural granite hills, incorporating the landscape into their architecture.
+
+### Architectural Innovation
+
+Khami represents an evolution in building techniques:
+- **Terracing** - Walls built as retaining structures for artificial platforms
+- **Decoration** - Distinctive checkered, herringbone, and cord patterns
+- **Integration** - Natural rock outcrops incorporated into structures
+- **Drainage** - Sophisticated systems to manage water runoff
+
+### International Trade
+
+Archaeological evidence reveals extensive trade networks:
+- **Chinese porcelain** from the Ming Dynasty
+- **Spanish coins** and trade goods
+- **German beads** from European traders
+- **Gold objects** and copper ingots
+- **Portuguese trade items** suggesting contact with explorers
+
+A small cross found at the site may indicate early contact with Portuguese missionaries, predating official records.
+
+### Decline
+
+Khami was destroyed by fire around 1683 during conflicts with the Rozvi dynasty under Changamire Dombo. The Rozvi subsequently established their capital at Danangombe (Dhlo Dhlo).
+
+---
+
+## What to See
+
+### The Hill Complex (Royal Area)
+
+The most impressive part of Khami, situated on a granite kopje overlooking the Khami River. This was likely the residence of the ruler.
+
+**Highlights:**
+- **Precipice Ruin** - The highest point with panoramic views
+- **Passage Ruin** - Features a narrow stone-lined passage
+- **Platform 1** - Largest terrace with decorated walls up to 6 meters high
+- **Checkered Wall** - Distinctive black and white decoration pattern
+
+### Cross Ruin
+
+Named after a small iron cross discovered here, possibly of Portuguese origin. This area shows evidence of:
+- European trade goods
+- Gold-working activities
+- Possible religious significance
+
+### The Museum
+
+A small but informative on-site museum displays:
+- Archaeological artifacts from excavations
+- Pottery and ceramic finds
+- Metal objects including gold
+- Imported trade items
+- Information panels on Khami's history
+
+### Natural Setting
+
+The ruins are set in beautiful natural surroundings:
+- Granite kopjes covered in vegetation
+- Views over the Khami River valley
+- Rich birdlife and occasional wildlife
+- Ancient baobab trees
+
+---
+
+## Comparing Khami to Great Zimbabwe
+
+| Feature | Great Zimbabwe | Khami |
+|---------|----------------|-------|
+| **Period** | 1100-1450 AD | 1450-1683 AD |
+| **Style** | Free-standing walls | Terraced platforms |
+| **Decoration** | Plain (except chevron) | Elaborate patterns |
+| **Terrain** | Flat valley | Natural hills |
+| **Purpose** | Royal + trade center | Royal capital |
+| **Size** | Larger complex | Smaller, more compact |
+
+---
+
+## Visiting Khami Ruins
+
+### Getting There
+
+**From Bulawayo (22 km):**
+- Head west on the Old Khami Road
+- Turn right at the signposted junction
+- Continue to the entrance gate
+- Drive time: approximately 30 minutes
+
+**GPS Coordinates:** -20.1594° S, 28.3728° E
+
+### What to Bring
+
+- Comfortable walking shoes (uneven terrain)
+- Sun protection (hat, sunscreen)
+- Water
+- Camera
+- Binoculars for birdwatching
+
+### Visitor Tips
+
+<Tip>
+**Best Time to Visit:** Early morning or late afternoon for photography and cooler temperatures. Weekdays are quieter than weekends.
+</Tip>
+
+- Allow 2-3 hours for a thorough visit
+- Hire a local guide at the entrance for deeper insights
+- Start at the museum to understand the site's context
+- The Hill Complex involves climbing - moderate fitness required
+- No food available on site - bring snacks if needed
+
+---
+
+## Practical Information
+
+### Entry Fees
+
+| Visitor Type | Fee (USD) |
+|--------------|-----------|
+| International Adults | $10 |
+| International Children | $5 |
+| SADC Adults | $5 |
+| SADC Children | $3 |
+| Zimbabwean Adults | $2 |
+| Zimbabwean Children | $1 |
+
+### Facilities
+
+- ✅ Parking
+- ✅ Toilets
+- ✅ On-site museum
+- ✅ Guides available
+- ❌ No restaurant (bring own refreshments)
+- ❌ Limited wheelchair access
+
+### Contact
+
+**National Museums and Monuments of Zimbabwe**
+- Phone: +263 29 226 2046
+- Website: www.nmmz.co.zw
+
+---
+
+## Nearby Attractions
+
+<CardGroup cols={2}>
+  <Card title="Bulawayo" icon="city" href="/destinations/bulawayo">
+    Zimbabwe's second city with colonial architecture and museums
+  </Card>
+  <Card title="Matobo Hills" icon="mountain" href="/destinations/matobo-hills">
+    Dramatic granite formations and world-class rock art (45 km)
+  </Card>
+  <Card title="Natural History Museum" icon="bone" href="/destinations/bulawayo">
+    One of the best museums in southern Africa (in Bulawayo)
+  </Card>
+  <Card title="Chipangali Wildlife Orphanage" icon="paw" href="/destinations/bulawayo">
+    Wildlife sanctuary and rehabilitation center (25 km)
+  </Card>
+</CardGroup>
+
+---
+
+## Suggested Itinerary: Bulawayo Heritage Circuit
+
+**Day 1: Bulawayo City**
+- Morning: Natural History Museum
+- Afternoon: Railway Museum & city tour
+- Evening: Dinner in the suburbs
+
+**Day 2: Khami Ruins**
+- Morning: Explore Khami (2-3 hours)
+- Afternoon: Drive to Matobo Hills
+- Evening: Sunset at World's View
+
+**Day 3: Matobo Hills**
+- Morning: Rock art sites (Nswatugi, Pomongwe)
+- Afternoon: Rhino tracking or game drive
+- Evening: Return to Bulawayo
+
+---
+
+## Conservation
+
+Khami Ruins is protected under Zimbabwean law and managed by the National Museums and Monuments of Zimbabwe (NMMZ). Visitors can support preservation by:
+
+- Staying on designated paths
+- Not climbing on walls or structures
+- Not removing any artifacts or stones
+- Reporting any damage to site staff
+- Paying entry fees (funds conservation)
+
+<Warning>
+It is illegal to remove any artifacts, stones, or materials from the site. Violators face prosecution under the National Museums and Monuments Act.
+</Warning>

--- a/heritage/khami-ruins.mdx
+++ b/heritage/khami-ruins.mdx
@@ -1,6 +1,25 @@
 ---
 title: "Khami Ruins"
-description: "Explore Khami Ruins, Zimbabwe's second UNESCO World Heritage Site - the ancient capital of the Torwa dynasty with distinctive terraced architecture"
+description: >-
+  Explore Khami Ruins, Zimbabwe's second UNESCO World Heritage Site - the ancient capital of the Torwa dynasty with distinctive terraced architecture
+'og:image': 'https://travel-info.co.zw/images/hero-light.svg'
+'og:site_name': "Zimbabwe Travel Information"
+'twitter:card': "summary_large_image"
+'twitter:site': '@zimbabwetravel'
+'twitter:creator': '@zimbabwetravel'
+robots: 'index, follow'
+author: "Zimbabwe Travel Information"
+keywords: >-
+  khami ruins, khame ruins, unesco zimbabwe, bulawayo ruins, torwa dynasty, butua state, zimbabwe archaeology, stone ruins zimbabwe, ancient zimbabwe
+'og:description': >-
+  Visit Khami Ruins near Bulawayo - Zimbabwe's second UNESCO World Heritage Site with distinctive decorated walls and terraced platforms.
+'twitter:description': >-
+  Khami Ruins - UNESCO World Heritage Site and ancient capital of the Torwa dynasty near Bulawayo.
+canonical: 'https://travel-info.co.zw/heritage/khami-ruins'
+'article:modified_time': '2025-12-30T00:00:00Z'
+'og:title': Khami Ruins UNESCO World Heritage Site | Zimbabwe Travel Information
+'og:type': "article"
+'schema:type': "TouristDestination"
 ---
 
 # Khami Ruins

--- a/heritage/minor-ruins.mdx
+++ b/heritage/minor-ruins.mdx
@@ -1,6 +1,25 @@
 ---
 title: "Lesser-Known Ruins of Zimbabwe"
-description: "Discover Zimbabwe's hidden archaeological treasures - from Mtoko's fortress ruins to the scattered stone sites throughout the country"
+description: >-
+  Discover Zimbabwe's hidden archaeological treasures - from Mtoko's fortress ruins to the scattered stone sites throughout the country
+'og:image': 'https://travel-info.co.zw/images/hero-light.svg'
+'og:site_name': "Zimbabwe Travel Information"
+'twitter:card': "summary_large_image"
+'twitter:site': '@zimbabwetravel'
+'twitter:creator': '@zimbabwetravel'
+robots: 'index, follow'
+author: "Zimbabwe Travel Information"
+keywords: >-
+  zimbabwe ruins, mtoko ruins, minor ruins zimbabwe, hidden ruins africa, archaeological sites zimbabwe, stone ruins, off beaten path zimbabwe
+'og:description': >-
+  Explore Zimbabwe's lesser-known ruins - hidden archaeological treasures beyond the famous UNESCO sites.
+'twitter:description': >-
+  Lesser-known ruins of Zimbabwe - hidden archaeological treasures for adventurous visitors.
+canonical: 'https://travel-info.co.zw/heritage/minor-ruins'
+'article:modified_time': '2025-12-30T00:00:00Z'
+'og:title': Lesser-Known Ruins of Zimbabwe | Zimbabwe Travel Information
+'og:type': "article"
+'schema:type': "TouristDestination"
 ---
 
 # Lesser-Known Ruins of Zimbabwe

--- a/heritage/minor-ruins.mdx
+++ b/heritage/minor-ruins.mdx
@@ -1,0 +1,310 @@
+---
+title: "Lesser-Known Ruins of Zimbabwe"
+description: "Discover Zimbabwe's hidden archaeological treasures - from Mtoko's fortress ruins to the scattered stone sites throughout the country"
+---
+
+# Lesser-Known Ruins of Zimbabwe
+
+<img src="/images/heritage/minor-ruins-zimbabwe.jpg" alt="Lesser known stone ruins in Zimbabwe" />
+
+Beyond the famous UNESCO sites and major monuments, Zimbabwe contains dozens of smaller stone-built sites that reward the adventurous visitor. These "minor" ruins often receive few visitors but preserve important examples of the Zimbabwe building tradition.
+
+---
+
+## Why Visit Minor Ruins?
+
+| Reason | Benefit |
+|--------|---------|
+| **Solitude** | Often have entire site to yourself |
+| **Authenticity** | Less developed, more atmospheric |
+| **Discovery** | Feel like an explorer |
+| **Local Knowledge** | Must engage with communities |
+| **Complete Picture** | Understand settlement patterns |
+
+---
+
+## Eastern Zimbabwe
+
+### Regina Ruins
+
+Near Nyanga, Regina represents the Nyanga agricultural tradition:
+
+**Features:**
+- Stone-walled terraces
+- Pit structures
+- Associated with Ziwa complex
+- Mountain setting
+
+| | |
+|---|---|
+| **Location** | Nyanga District, Manicaland |
+| **Type** | Agricultural complex |
+| **Period** | Similar to Ziwa (~1500-1800 AD) |
+| **Access** | Moderate |
+
+### Nyangwe Fort
+
+A stone-built fortification in the Eastern Highlands:
+
+**Significance:**
+- Defensive architecture
+- Part of Nyanga complex
+- Panoramic views
+- Combined with Ziwa visits
+
+| | |
+|---|---|
+| **Location** | Nyanga District |
+| **Type** | Fort/defensive structure |
+| **Access** | Requires hiking |
+
+### Van Niekerk Ruins
+
+Named after early researcher, featuring:
+- Agricultural terraces
+- Nyanga building tradition
+- Less visited than Ziwa
+- Academic interest
+
+---
+
+## Central Zimbabwe
+
+### Mtoko Ruins
+
+<img src="/images/heritage/mtoko-ruins.jpg" alt="Mtoko ruins" />
+
+Stone-walled structures in Mtoko District showing:
+
+**Features:**
+- Dry-stone walls
+- Hillside location
+- Defensive positioning
+- Connection to trade routes
+
+**History:**
+- Built by ancestors of local Shona peoples
+- Controlled territory in pre-colonial era
+- Abandoned during colonial period
+- Local spiritual significance remains
+
+| | |
+|---|---|
+| **Location** | Mtoko District, Mashonaland East |
+| **Distance from Harare** | ~150 km |
+| **Access** | Local enquiry needed |
+| **Guide** | Essential |
+
+### Harleigh Farm Ruins
+
+Near Rusape, an interesting minor site:
+
+**Features:**
+- Stone walling
+- Agricultural evidence
+- Colonial-era farm overlay
+- Less documented
+
+---
+
+## Midlands Region
+
+### Ntaba zika Mambo
+
+"Hill of the Chief" - a significant site near Gweru:
+
+**Features:**
+- Stone walling
+- Hilltop location
+- Royal associations
+- Connection to later dynasties
+
+**Significance:**
+- Shows continuity of settlement
+- Royal seat before colonial period
+- Less visited than major ruins
+- Important regional center
+
+### Matendere
+
+On the UNESCO Tentative List, Matendere deserves wider recognition:
+
+**Features:**
+- Well-preserved walls
+- Decorative elements
+- Rozvi period construction
+- Important trading site
+
+| | |
+|---|---|
+| **Status** | UNESCO Tentative List (since 1997) |
+| **Period** | Rozvi Empire |
+| **Location** | Midlands Province |
+| **Significance** | Trade and political center |
+
+---
+
+## Matabeleland
+
+### Manyanga Ruins
+
+Near Bulawayo, showing:
+- Ndebele-era modifications
+- Earlier stone structures
+- Historical layering
+- Local access
+
+### Nata River Sites
+
+In northern Matabeleland:
+- Scattered stone structures
+- Salt trade connections
+- Remote locations
+- Research opportunities
+
+---
+
+## Understanding Minor Ruins
+
+### Site Types
+
+| Type | Characteristics | Examples |
+|------|-----------------|----------|
+| **Hilltop Forts** | Defensive walls, views | Mtoko, Nyangwe |
+| **Agricultural** | Terraces, pit structures | Ziwa complex sites |
+| **Trading Posts** | Strategic locations | Matendere |
+| **Royal Seats** | Decorated walls, platforms | Minor Rozvi sites |
+| **Village Sites** | Simple enclosures | Numerous unnamed |
+
+### Dating and Periods
+
+| Period | Approximate Dates | Characteristics |
+|--------|-------------------|-----------------|
+| **Early** | 1100-1450 AD | Great Zimbabwe tradition |
+| **Middle** | 1450-1683 AD | Torwa/Butua period |
+| **Late** | 1683-1830 AD | Rozvi period |
+| **Final** | 1830-1890 | Ndebele modifications |
+
+### Who Built Them?
+
+These sites were built by:
+- Ancestors of modern Shona peoples
+- Local chiefs and rulers
+- Agricultural communities
+- Trading societies
+
+They represent:
+- Local political power
+- Territorial control
+- Agricultural innovation
+- Spiritual significance
+
+---
+
+## Visiting Minor Ruins
+
+### General Tips
+
+1. **Research first** - Limited information online
+2. **Ask locally** - Communities know sites
+3. **Respect traditions** - Many sites are sacred
+4. **Go with guides** - Navigation and permission
+5. **Allow time** - Finding sites takes effort
+6. **Manage expectations** - Less impressive than major ruins
+
+### How to Find Sites
+
+**Resources:**
+- National Museums and Monuments of Zimbabwe
+- University archaeology departments
+- Local museums (Masvingo, Gweru)
+- Community knowledge
+- Older guidebooks and academic papers
+
+**Approach:**
+1. Contact NMMZ for site information
+2. Ask about permission requirements
+3. Find local guides through:
+   - Community leaders
+   - Schools
+   - Hotels/lodges
+   - Tour operators
+
+### What to Expect
+
+**Facilities:** Usually none - bring everything you need
+**Signage:** Rare or absent
+**Paths:** Often overgrown
+**Guides:** Local, informal arrangement
+**Fees:** Variable - community contributions expected
+
+---
+
+## Conservation Concerns
+
+Minor ruins face greater threats than protected sites:
+
+| Threat | Impact |
+|--------|--------|
+| **Neglect** | Vegetation overgrowth, collapse |
+| **Agriculture** | Stone robbing for fields |
+| **Development** | Construction damage |
+| **Lack of awareness** | Not valued locally |
+| **Limited funding** | No maintenance budget |
+
+**How to Help:**
+- Visit and raise awareness
+- Document sites photographically
+- Report damage to NMMZ
+- Support local conservation
+- Share information responsibly
+
+---
+
+## Suggested Approach
+
+### For Enthusiasts
+
+**Multi-day exploration:**
+- Base yourself in a region
+- Connect with local museum
+- Hire knowledgeable guide
+- Visit multiple sites
+- Document systematically
+
+### For Casual Visitors
+
+**Combine with major sites:**
+- Visit Khami, ask about nearby sites
+- At Great Zimbabwe, enquire about Nemanwa
+- In Nyanga, explore beyond Ziwa
+
+### For Researchers
+
+**Academic approach:**
+- Contact University of Zimbabwe
+- Work with NMMZ
+- Obtain proper permissions
+- Contribute to knowledge
+- Publish findings
+
+---
+
+## List of Known Minor Sites
+
+This is not exhaustive - many sites remain undocumented:
+
+| Site | Province | Type | Access |
+|------|----------|------|--------|
+| Mtoko Ruins | Mashonaland East | Fort | Difficult |
+| Regina | Manicaland | Agricultural | Moderate |
+| Nyangwe Fort | Manicaland | Fort | Moderate |
+| Ntaba zika Mambo | Midlands | Royal | Difficult |
+| Matendere | Midlands | Trading | Moderate |
+| Manyanga | Matabeleland | Mixed | Moderate |
+| Nemanwa | Masvingo | Zimbabwe tradition | Easy |
+| Various Nyanga sites | Manicaland | Agricultural | Variable |
+
+<Card title="The Undiscovered Country" icon="compass">
+Zimbabwe's archaeological heritage extends far beyond the famous sites. For those willing to make the effort, lesser-known ruins offer intimate encounters with the past that no major tourist site can match. You might be the first visitor in months - or years.
+</Card>

--- a/heritage/naletale-ruins.mdx
+++ b/heritage/naletale-ruins.mdx
@@ -1,0 +1,235 @@
+---
+title: "Naletale Ruins"
+description: "Discover Naletale Ruins - a masterpiece of stone architecture featuring Zimbabwe's most intricate decorative wall patterns"
+---
+
+# Naletale Ruins
+
+<img src="/images/heritage/naletale-ruins.jpg" alt="Naletale Ruins decorative walls" />
+
+**Naletale Ruins** is considered the pinnacle of dry-stone walling artistry in Zimbabwe. Located in the Midlands Province near Shangani, this 17th-century site features the most elaborate and intricate wall decorations found anywhere in the country, representing the finest achievement of the Rozvi dynasty's builders.
+
+<Info>
+**UNESCO Tentative List** - Naletale has been on Zimbabwe's UNESCO World Heritage Tentative List since 1997, recognized for its exceptional decorative stonework.
+</Info>
+
+---
+
+## Quick Facts
+
+| | |
+|---|---|
+| **Location** | Shangani area, Midlands Province |
+| **Period** | c. 1650-1750 AD |
+| **Kingdom** | Rozvi Empire (Changamire dynasty) |
+| **Known For** | Most elaborate wall decorations in Zimbabwe |
+| **Status** | National Monument, UNESCO Tentative List |
+| **Entry Fee** | $5 USD |
+
+---
+
+## Why Naletale is Special
+
+### The Art of Dry-Stone Walling
+
+While Great Zimbabwe and Khami are larger and more famous, Naletale represents the **artistic peak** of Zimbabwe's stone-building tradition. The walls feature:
+
+- **Chevron patterns** in multiple variations
+- **Herringbone designs** with precise geometry
+- **Checkered patterns** using contrasting stones
+- **Cord patterns** resembling twisted rope
+- **Dentelle (lace) patterns** of extraordinary delicacy
+- **Combined motifs** creating complex compositions
+
+The builders achieved these effects using carefully selected stones of different colors and sizes, all fitted together without mortar.
+
+### A Living Canvas in Stone
+
+The main enclosure wall is essentially a decorated masterpiece covering approximately 90 meters in circumference. Every section displays different patterns, as if the builders were demonstrating the full range of their artistic abilities.
+
+---
+
+## History
+
+### Rozvi Empire Context
+
+Naletale was built during the height of the Rozvi Empire, which succeeded the Torwa dynasty after the destruction of Khami around 1683. The Rozvi, under their Changamire rulers, controlled much of present-day Zimbabwe and were renowned for their:
+
+- Military prowess
+- Cattle wealth
+- Stone-building expertise
+- Control of gold trade routes
+
+### Purpose and Function
+
+Naletale is believed to have served as:
+- A provincial capital or administrative center
+- Residence of a Rozvi noble or governor
+- A ceremonial site
+- A demonstration of Rozvi power and sophistication
+
+### Decline
+
+Like other Rozvi sites, Naletale was abandoned during the upheavals of the early 19th century, including the Ndebele invasion under Mzilikazi. By the time European explorers documented the site, it had long been unoccupied.
+
+---
+
+## What to See
+
+### The Main Enclosure
+
+The star attraction featuring the famous decorated walls:
+- **Circumference:** ~90 meters
+- **Wall height:** Up to 4 meters
+- **Thickness:** 1-2 meters
+
+Walk around the exterior to appreciate the full range of decorative patterns. Each section is unique.
+
+### Pattern Gallery
+
+| Pattern | Description | Location |
+|---------|-------------|----------|
+| **Chevron** | V-shaped zigzag pattern | Multiple sections |
+| **Herringbone** | Diagonal lines creating fish-bone effect | East wall |
+| **Checker** | Alternating colored blocks | North wall |
+| **Cord** | Twisted rope appearance | Various sections |
+| **Dentelle** | Delicate lace-like design | Showcase sections |
+
+### Interior Features
+
+- Central platform area
+- Stone-lined drains
+- Entrance passages
+- Collapsed internal structures
+
+### Surrounding Area
+
+- Secondary enclosures
+- Beautiful granite kopje setting
+- Indigenous vegetation
+- Peaceful, remote atmosphere
+
+---
+
+## Comparing Zimbabwe's Ruins
+
+| Site | Period | Style | Decoration | Best For |
+|------|--------|-------|------------|----------|
+| **Great Zimbabwe** | 1100-1450 | Monumental | Minimal | Scale, history |
+| **Khami** | 1450-1683 | Terraced | Moderate | UNESCO, accessibility |
+| **Naletale** | 1650-1750 | Compact | Exceptional | Artistry, decoration |
+| **Dhlo Dhlo** | 1650-1800 | Sprawling | Good | Atmosphere, size |
+
+---
+
+## Visiting Naletale
+
+### Getting There
+
+**From Gweru (80 km):**
+1. Take the Bulawayo road west
+2. At Shangani, turn north (signposted)
+3. Follow the dirt road to the site
+4. Drive time: ~1.5 hours
+
+**From Bulawayo (150 km):**
+1. Take the Harare road east
+2. At Shangani, turn north
+3. Follow signs to Naletale
+
+<Warning>
+The access road can be rough, especially in the rainy season. A high-clearance vehicle is recommended. Check conditions locally before visiting.
+</Warning>
+
+**GPS Coordinates:** -19.2347° S, 29.1028° E
+
+### Practical Information
+
+| | |
+|---|---|
+| **Entry Fee** | $5 USD |
+| **Hours** | Daylight hours (no formal gate) |
+| **Facilities** | Very limited - bring everything you need |
+| **Guides** | May be available - ask locally |
+| **Time Needed** | 1-2 hours |
+
+### What to Bring
+
+- Water and snacks (no facilities)
+- Sun protection
+- Good walking shoes
+- Camera with good zoom lens
+- Binoculars (for wall detail viewing)
+
+### Best Time to Visit
+
+- **Dry season (May-October):** Easier access, clearer skies
+- **Morning light:** Best for photography of east-facing walls
+- **Weekdays:** More solitude at this remote site
+
+---
+
+## Tips for Photographers
+
+Naletale is a photographer's paradise. Tips for capturing the decorative walls:
+
+1. **Side lighting** (early morning/late afternoon) reveals texture
+2. **Get close** to capture pattern details
+3. **Wide angles** show the full wall sweep
+4. **Use a polarizer** to reduce glare on stones
+5. **Include scale** (person, object) to show wall size
+
+---
+
+## Combining with Other Sites
+
+### Midlands Heritage Circuit
+
+**Day 1: Gweru**
+- Explore Gweru town
+- Midlands Museum
+- Overnight in Gweru
+
+**Day 2: Naletale & Danangombe**
+- Morning: Naletale Ruins (1.5 hours)
+- Drive to Danangombe/Dhlo Dhlo (additional ruins)
+- Return to Gweru or continue to Bulawayo
+
+**Day 3: Continue Journey**
+- Option A: North to Harare
+- Option B: West to Khami and Bulawayo
+- Option C: South to Great Zimbabwe
+
+---
+
+## Conservation Status
+
+Naletale is a protected National Monument under the care of NMMZ (National Museums and Monuments of Zimbabwe). The site's remote location has helped preserve it, but also means:
+
+- Limited security presence
+- Minimal infrastructure
+- Ongoing weathering concerns
+- Need for visitor respect
+
+**How you can help:**
+- Stay on paths
+- Don't touch decorated walls
+- Take only photographs
+- Report any damage
+- Support local guides
+
+---
+
+## Nearby Attractions
+
+| Attraction | Distance | Description |
+|------------|----------|-------------|
+| Danangombe (Dhlo Dhlo) | 40 km | Another major Rozvi ruin |
+| Gweru | 80 km | Provincial capital, museums |
+| Antelope Park | 100 km | Wildlife experience |
+| Khami Ruins | 150 km | UNESCO World Heritage Site |
+| Great Zimbabwe | 200 km | The famous stone ruins |
+
+<Card title="Hidden Gem" icon="gem">
+Naletale sees far fewer visitors than Great Zimbabwe or Victoria Falls, offering an authentic, uncrowded experience of Zimbabwe's remarkable heritage. For those who make the journey, it's an unforgettable encounter with ancient artistry.
+</Card>

--- a/heritage/naletale-ruins.mdx
+++ b/heritage/naletale-ruins.mdx
@@ -1,6 +1,25 @@
 ---
 title: "Naletale Ruins"
-description: "Discover Naletale Ruins - a masterpiece of stone architecture featuring Zimbabwe's most intricate decorative wall patterns"
+description: >-
+  Discover Naletale Ruins - a masterpiece of stone architecture featuring Zimbabwe's most intricate decorative wall patterns
+'og:image': 'https://travel-info.co.zw/images/hero-light.svg'
+'og:site_name': "Zimbabwe Travel Information"
+'twitter:card': "summary_large_image"
+'twitter:site': '@zimbabwetravel'
+'twitter:creator': '@zimbabwetravel'
+robots: 'index, follow'
+author: "Zimbabwe Travel Information"
+keywords: >-
+  naletale ruins, rozvi empire, zimbabwe ruins, decorated walls, shangani ruins, midlands zimbabwe, stone architecture africa, chevron pattern walls
+'og:description': >-
+  Naletale Ruins features Zimbabwe's most elaborate decorated stone walls - a masterpiece of Rozvi architecture near Shangani.
+'twitter:description': >-
+  Naletale Ruins - Zimbabwe's finest decorated stone walls and a masterpiece of Rozvi Empire architecture.
+canonical: 'https://travel-info.co.zw/heritage/naletale-ruins'
+'article:modified_time': '2025-12-30T00:00:00Z'
+'og:title': Naletale Ruins - Finest Decorated Walls | Zimbabwe Travel Information
+'og:type': "article"
+'schema:type': "TouristDestination"
 ---
 
 # Naletale Ruins

--- a/heritage/unesco-world-heritage.mdx
+++ b/heritage/unesco-world-heritage.mdx
@@ -1,6 +1,25 @@
 ---
 title: "UNESCO World Heritage Sites"
-description: "Explore Zimbabwe's five UNESCO World Heritage Sites - ancient ruins, dramatic landscapes, and natural wonders of outstanding universal value"
+description: >-
+  Explore Zimbabwe's five UNESCO World Heritage Sites - ancient ruins, dramatic landscapes, and natural wonders of outstanding universal value
+'og:image': 'https://travel-info.co.zw/images/hero-light.svg'
+'og:site_name': "Zimbabwe Travel Information"
+'twitter:card': "summary_large_image"
+'twitter:site': '@zimbabwetravel'
+'twitter:creator': '@zimbabwetravel'
+robots: 'index, follow'
+author: "Zimbabwe Travel Information"
+keywords: >-
+  unesco zimbabwe, world heritage sites zimbabwe, great zimbabwe, victoria falls unesco, mana pools, matobo hills, khami ruins, zimbabwe heritage, african world heritage
+'og:description': >-
+  Discover Zimbabwe's five UNESCO World Heritage Sites - Great Zimbabwe, Victoria Falls, Mana Pools, Matobo Hills, and Khami Ruins.
+'twitter:description': >-
+  Zimbabwe's five UNESCO World Heritage Sites - ancient ruins and natural wonders of outstanding universal value.
+canonical: 'https://travel-info.co.zw/heritage/unesco-world-heritage'
+'article:modified_time': '2025-12-30T00:00:00Z'
+'og:title': UNESCO World Heritage Sites in Zimbabwe | Zimbabwe Travel Information
+'og:type': "article"
+'schema:type': "TouristDestination"
 ---
 
 import { Card, CardGroup } from '/snippets/card-components.mdx'

--- a/heritage/unesco-world-heritage.mdx
+++ b/heritage/unesco-world-heritage.mdx
@@ -1,0 +1,204 @@
+---
+title: "UNESCO World Heritage Sites"
+description: "Explore Zimbabwe's five UNESCO World Heritage Sites - ancient ruins, dramatic landscapes, and natural wonders of outstanding universal value"
+---
+
+import { Card, CardGroup } from '/snippets/card-components.mdx'
+
+# UNESCO World Heritage Sites in Zimbabwe
+
+Zimbabwe is home to **five UNESCO World Heritage Sites**, representing some of Africa's most significant cultural and natural treasures. These sites have been recognized for their outstanding universal value to humanity.
+
+<CardGroup cols={2}>
+  <Card title="Great Zimbabwe" icon="landmark" href="/destinations/great-zimbabwe">
+    Africa's largest ancient stone structure and the symbol of a great medieval kingdom
+  </Card>
+  <Card title="Khami Ruins" icon="building-columns" href="/heritage/khami-ruins">
+    The second largest stone-built monument in Zimbabwe after Great Zimbabwe
+  </Card>
+  <Card title="Victoria Falls" icon="water" href="/destinations/victoria-falls">
+    "The Smoke That Thunders" - one of the world's largest and most spectacular waterfalls
+  </Card>
+  <Card title="Mana Pools" icon="hippo" href="/destinations/mana-pools">
+    A pristine wilderness where elephants, lions, and wild dogs roam free
+  </Card>
+  <Card title="Matobo Hills" icon="mountain" href="/destinations/matobo-hills">
+    Dramatic granite formations with the world's highest concentration of rock art
+  </Card>
+</CardGroup>
+
+---
+
+## Cultural Heritage Sites
+
+### Great Zimbabwe (Inscribed 1986)
+
+<img src="/images/heritage/great-zimbabwe-ruins.jpg" alt="Great Zimbabwe stone walls" />
+
+The ruins of Great Zimbabwe are the largest collection of ruins in Africa south of the Sahara. Built between the 11th and 15th centuries, the site was the capital of the Kingdom of Zimbabwe during the Late Iron Age and was home to a Shona trading empire that controlled much of the region.
+
+**Why it's significant:**
+- Largest ancient stone structure in sub-Saharan Africa
+- Evidence of a sophisticated pre-colonial African civilization
+- The name "Zimbabwe" derives from the Shona "dzimba-dza-mabwe" (houses of stone)
+- The iconic soapstone Zimbabwe Birds found here are now the national emblem
+
+**Key Features:**
+- **The Great Enclosure** - The largest single ancient structure in sub-Saharan Africa
+- **The Hill Complex** - The oldest part of the ruins, likely a royal residence
+- **The Valley Ruins** - Residential areas for the city's estimated 18,000 inhabitants
+
+[Explore Great Zimbabwe →](/destinations/great-zimbabwe)
+
+---
+
+### Khami Ruins (Inscribed 1986)
+
+<img src="/images/heritage/khami-ruins.jpg" alt="Khami Ruins terraced walls" />
+
+Khami (also spelled Khame) was the capital of the Torwa dynasty which succeeded the Great Zimbabwe kingdom. Located 22 km west of Bulawayo, Khami represents an important phase in Zimbabwean history and showcases architectural techniques that evolved from Great Zimbabwe.
+
+**Why it's significant:**
+- Second largest stone-built monument in Zimbabwe
+- Demonstrates evolution of dry-stone walling techniques
+- Evidence of international trade (Chinese, Spanish, and German artifacts found)
+- Capital of the Butua State (1450-1683)
+
+**Key Features:**
+- Decorated retaining walls with distinctive checkered patterns
+- Terraced platforms built on natural granite hills
+- Cross found at the site suggests early Portuguese contact
+- Integrated building style with natural rock formations
+
+[Explore Khami Ruins →](/heritage/khami-ruins)
+
+---
+
+## Natural Heritage Sites
+
+### Victoria Falls / Mosi-oa-Tunya (Inscribed 1989)
+
+<img src="/images/destinations/victoria-falls-aerial.jpg" alt="Victoria Falls aerial view" />
+
+Known locally as "Mosi-oa-Tunya" (The Smoke That Thunders), Victoria Falls is one of the most spectacular waterfalls in the world. The falls are 1,708 meters wide and 108 meters high, creating the largest curtain of falling water on Earth.
+
+**Why it's significant:**
+- One of the Seven Natural Wonders of the World
+- Creates the largest sheet of falling water on Earth
+- Spray can be seen from 50 km away
+- Supports unique "rain forest" ecosystem from constant spray
+
+**Shared Site:** This is a transboundary World Heritage Site shared between Zimbabwe and Zambia.
+
+[Explore Victoria Falls →](/destinations/victoria-falls)
+
+---
+
+### Mana Pools National Park (Inscribed 1984)
+
+<img src="/images/destinations/mana-pools-elephants.jpg" alt="Elephants at Mana Pools" />
+
+Mana Pools, along with the Sapi and Chewore Safari Areas, is recognized for its pristine wilderness and exceptional wildlife populations. The floodplains and terraces along the Zambezi River create a unique ecosystem where predators and prey interact in an unspoiled environment.
+
+**Why it's significant:**
+- One of Africa's least developed and most pristine wilderness areas
+- Famous for walking safaris among dangerous game
+- Home to endangered species including black rhino and wild dog
+- "Mana" means "four" in Shona, referring to the four main pools
+
+**Key Wildlife:**
+- Large elephant herds (famous for standing on hind legs to reach trees)
+- One of the best places to see African wild dogs
+- Excellent lion and leopard sightings
+- Over 350 bird species
+
+[Explore Mana Pools →](/destinations/mana-pools)
+
+---
+
+### Matobo Hills (Inscribed 2003)
+
+<img src="/images/destinations/matobo-hills-rocks.jpg" alt="Matobo Hills granite formations" />
+
+The Matobo Hills contain one of the highest concentrations of rock art in the world, with over 3,000 documented sites. The dramatic granite landscape has been continuously inhabited for over 100,000 years, making it one of the longest-occupied places on Earth.
+
+**Why it's significant:**
+- Over 3,000 rock art sites spanning 13,000 years
+- Highest concentration of rock art in the world
+- Continuous human occupation for 100,000+ years
+- Sacred site for the Mwari religion (God of the Matobo)
+
+**Key Features:**
+- **Nswatugi Cave** - Exceptional rock paintings including giraffes and kudu
+- **Pomongwe Cave** - Important archaeological site with 40,000-year history
+- **Bambata Cave** - Gave its name to the "Bambata" Stone Age culture
+- **World's View** - Burial site of Cecil John Rhodes
+
+[Explore Matobo Hills →](/destinations/matobo-hills)
+
+---
+
+## Tentative List Sites
+
+Zimbabwe has also submitted several sites to the UNESCO Tentative List for future consideration:
+
+| Site | Type | Submitted |
+|------|------|-----------|
+| Ziwa National Monument | Cultural | 1997 |
+| Nalatale Ruins | Cultural | 1997 |
+| Matendere | Cultural | 1997 |
+| Danamombe (Dhlo Dhlo) | Cultural | 1997 |
+
+These sites represent additional cultural treasures that may receive World Heritage status in the future.
+
+---
+
+## Planning Your Heritage Visit
+
+### Suggested Itinerary: UNESCO Heritage Trail
+
+**Day 1-2: Bulawayo Area**
+- Explore Khami Ruins
+- Visit Matobo Hills (rock art sites)
+
+**Day 3-4: Masvingo**
+- Full day at Great Zimbabwe
+- Visit the site museum
+
+**Day 5-7: Victoria Falls**
+- Experience the falls from multiple viewpoints
+- Optional activities: sunset cruise, helicopter flight
+
+**Day 8-10: Mana Pools**
+- Walking safaris
+- Game drives and canoe trips
+
+### Practical Information
+
+| Site | Entry Fee (USD) | Hours | Time Needed |
+|------|-----------------|-------|-------------|
+| Great Zimbabwe | $15 | 8am-5pm | Half day |
+| Khami Ruins | $10 | 8am-5pm | 2-3 hours |
+| Victoria Falls | $50 | 6am-6pm | Half day |
+| Mana Pools | $40/day | Dawn-dusk | 2-3 days |
+| Matobo Hills | $15 | 6am-6pm | Full day |
+
+<Note>
+Fees are approximate and subject to change. National Parks fees may be higher for non-SADC residents.
+</Note>
+
+---
+
+## Conservation & Preservation
+
+Zimbabwe's National Museums and Monuments of Zimbabwe (NMMZ) and the Zimbabwe Parks and Wildlife Management Authority (ZimParks) work together to preserve these irreplaceable sites. When visiting:
+
+- Stay on designated paths
+- Do not touch rock art or ancient structures
+- Take only photographs, leave only footprints
+- Support local communities and conservation efforts
+- Report any damage or vandalism to site authorities
+
+<Card title="Support Conservation" icon="hand-holding-heart">
+Consider contributing to conservation efforts through responsible tourism and donations to preservation organizations working in Zimbabwe.
+</Card>

--- a/heritage/ziwa-ruins.mdx
+++ b/heritage/ziwa-ruins.mdx
@@ -1,6 +1,25 @@
 ---
 title: "Ziwa National Monument"
-description: "Discover Ziwa - a remarkable archaeological site in the Eastern Highlands featuring ancient agricultural terraces and stone-lined pit structures"
+description: >-
+  Discover Ziwa - a remarkable archaeological site in the Eastern Highlands featuring ancient agricultural terraces and stone-lined pit structures
+'og:image': 'https://travel-info.co.zw/images/hero-light.svg'
+'og:site_name': "Zimbabwe Travel Information"
+'twitter:card': "summary_large_image"
+'twitter:site': '@zimbabwetravel'
+'twitter:creator': '@zimbabwetravel'
+robots: 'index, follow'
+author: "Zimbabwe Travel Information"
+keywords: >-
+  ziwa ruins, nyanga archaeology, eastern highlands zimbabwe, agricultural terraces, pit structures, nyanga national monument, ancient farming africa
+'og:description': >-
+  Ziwa National Monument in Nyanga - ancient agricultural terraces and mysterious pit structures in the Eastern Highlands.
+'twitter:description': >-
+  Ziwa - ancient agricultural terraces and pit structures in Zimbabwe's Eastern Highlands.
+canonical: 'https://travel-info.co.zw/heritage/ziwa-ruins'
+'article:modified_time': '2025-12-30T00:00:00Z'
+'og:title': Ziwa National Monument | Zimbabwe Travel Information
+'og:type': "article"
+'schema:type': "TouristDestination"
 ---
 
 # Ziwa National Monument

--- a/heritage/ziwa-ruins.mdx
+++ b/heritage/ziwa-ruins.mdx
@@ -1,0 +1,256 @@
+---
+title: "Ziwa National Monument"
+description: "Discover Ziwa - a remarkable archaeological site in the Eastern Highlands featuring ancient agricultural terraces and stone-lined pit structures"
+---
+
+# Ziwa National Monument
+
+<img src="/images/heritage/ziwa-ruins.jpg" alt="Ziwa terraced agricultural site" />
+
+**Ziwa National Monument** is one of Zimbabwe's most intriguing archaeological sites, located in the scenic Nyanga highlands of the Eastern Highlands. Unlike the royal capitals of the Zimbabwe tradition, Ziwa represents an ancient agricultural society that transformed the landscape with extensive terracing and unique stone-lined pit structures.
+
+<Info>
+**UNESCO Tentative List** - Ziwa has been on Zimbabwe's UNESCO World Heritage Tentative List since 1997, recognized for its unique agricultural heritage and archaeological significance.
+</Info>
+
+---
+
+## Quick Facts
+
+| | |
+|---|---|
+| **Location** | Nyanga District, Manicaland Province |
+| **Period** | c. 1500-1800 AD (possibly earlier) |
+| **Culture** | Nyanga Agricultural Complex |
+| **Known For** | Agricultural terraces, pit structures |
+| **Status** | National Monument, UNESCO Tentative List |
+| **Altitude** | ~1,800 meters |
+| **Entry Fee** | $5 USD |
+
+---
+
+## What Makes Ziwa Unique
+
+### Not Like Other Zimbabwe Ruins
+
+While Great Zimbabwe, Khami, and Naletale were elite residences and capitals, Ziwa represents something entirely different:
+
+- **Agricultural focus** rather than royal/ceremonial
+- **Terraced hillsides** for farming
+- **Stone-lined pits** (purpose debated)
+- **No great enclosing walls** like traditional ruins
+- **Community-based** rather than hierarchical
+
+### The Nyanga Complex
+
+Ziwa is part of a broader phenomenon in the Nyanga highlands where ancient peoples created:
+- Over 9,000 km² of terraced hillsides
+- Thousands of pit structures
+- Stone-lined enclosures for livestock
+- Sophisticated water management systems
+
+---
+
+## Archaeological Features
+
+### Agricultural Terraces
+
+The most visible features are extensive stone-walled terraces:
+- Built to create level planting surfaces
+- Prevent soil erosion on steep slopes
+- Capture and retain water
+- Cover many hectares of hillside
+
+These terraces demonstrate sophisticated agricultural knowledge and massive community labor investment.
+
+### Pit Structures
+
+The most mysterious features at Ziwa are the stone-lined pits:
+
+**Characteristics:**
+- Circular or oval shape
+- 1-3 meters deep
+- Stone-lined walls
+- Often with underground tunnels connecting them
+- Sometimes covered with stone caps
+
+**Theories about their purpose:**
+| Theory | Evidence For | Questions |
+|--------|--------------|-----------|
+| Cattle byres (overnight pens) | Size, shape, dung deposits | Why underground? |
+| Cold storage | Cool temperatures in highlands | What was stored? |
+| Defensive hiding places | Tunnel connections | From whom? |
+| Ritual purposes | Associated artifacts | What rituals? |
+| Grain storage | Similar to known structures | Why so elaborate? |
+
+The most widely accepted theory is that these were livestock enclosures, with the pits providing protection from cold highland nights and predators.
+
+### Stone Forts
+
+Ziwa also features several **stone forts** or defensive structures:
+- Built on hilltops and ridges
+- Thick walls for defense
+- Commanding views of surrounding area
+- May indicate conflict or need for protection
+
+---
+
+## The Nyanga People
+
+### Who Built Ziwa?
+
+The builders of Ziwa and the broader Nyanga complex were:
+- Bantu-speaking agriculturalists
+- Skilled in stone construction
+- Practiced mixed farming (crops and livestock)
+- May be ancestors of modern Shona peoples
+- Active from around 1500-1800 AD (possibly earlier)
+
+### Why This Location?
+
+The Nyanga highlands offered:
+- **Fertile soils** (volcanic origin)
+- **Reliable rainfall** (orographic effects)
+- **Cooler climate** (suitable for certain crops)
+- **Defensible terrain** (hills and mountains)
+- **Grazing land** for cattle
+
+### Decline
+
+The intensive agricultural systems were largely abandoned by the 19th century, possibly due to:
+- Population movements during Mfecane
+- Climate changes
+- Soil exhaustion
+- Conflict and displacement
+
+---
+
+## Visiting Ziwa
+
+### Getting There
+
+**From Nyanga Village (20 km):**
+1. Head south from Nyanga on the main road
+2. Watch for signposts to Ziwa
+3. Turn onto the access road
+4. Site is well-marked
+
+**From Mutare (100 km):**
+1. Take the Nyanga road north
+2. Pass through Juliasdale
+3. Continue toward Nyanga
+4. Turn at Ziwa signpost
+
+**From Harare (270 km):**
+1. Take the Mutare road (A3)
+2. Turn north at Rusape toward Nyanga
+3. Continue to Ziwa turn-off
+
+**GPS Coordinates:** -18.3167° S, 32.7500° E
+
+### Practical Information
+
+| | |
+|---|---|
+| **Entry Fee** | $5 USD |
+| **Hours** | 8:00 AM - 5:00 PM |
+| **Facilities** | Basic (toilets, parking) |
+| **Guides** | Available |
+| **Time Needed** | 2-3 hours |
+| **Difficulty** | Moderate (hillside walking) |
+
+### What to Bring
+
+- **Warm clothing** - highland climate can be cool
+- **Good walking shoes** - uneven terrain
+- **Water and snacks**
+- **Camera**
+- **Binoculars** - good birding area
+
+### Best Time to Visit
+
+- **Dry season (May-October)** - easier walking, clearer views
+- **Avoid rainy season** - paths can be slippery
+- **Morning visits** - best light for photography
+
+---
+
+## Combining with Nyanga Area Attractions
+
+The Eastern Highlands offer many attractions near Ziwa:
+
+### Nature and Scenery
+
+| Attraction | Distance | Highlights |
+|------------|----------|------------|
+| Nyanga National Park | 15 km | Mtarazi Falls (highest in Zimbabwe), hiking |
+| World's View | 25 km | Panoramic views, scenic drive |
+| Pungwe Falls | 30 km | Beautiful waterfall, forest walk |
+| Troutbeck | 20 km | Highland resort, fly fishing |
+
+### Other Archaeological Sites
+
+| Site | Distance | Features |
+|------|----------|----------|
+| Nyangwe Fort | 10 km | Stone fort ruins |
+| Van Niekerk Ruins | 15 km | Agricultural terraces |
+| Numerous pit structures | Various | Scattered throughout highlands |
+
+---
+
+## Suggested Itinerary: Eastern Highlands Heritage
+
+**Day 1: Arrive Nyanga**
+- Settle into accommodation
+- Evening walk or drive
+
+**Day 2: Ziwa & Archaeological Sites**
+- Morning: Ziwa National Monument (2-3 hours)
+- Afternoon: Explore other pit structures and terraces
+- Evening: Relax at lodge
+
+**Day 3: Natural Wonders**
+- Morning: Mtarazi Falls hike
+- Afternoon: Pungwe Falls
+- Evening: Sunset at World's View
+
+**Day 4: Continue Journey**
+- Option A: North to Nyanga National Park
+- Option B: South to Chimanimani
+- Option C: Return to Harare
+
+---
+
+## Conservation
+
+Ziwa is managed by the National Museums and Monuments of Zimbabwe (NMMZ). Conservation challenges include:
+
+- Vegetation encroachment on structures
+- Agricultural expansion in surrounding areas
+- Limited funding for maintenance
+- Need for more research and documentation
+
+**Visitor responsibilities:**
+- Stay on marked paths
+- Don't remove any materials
+- Report damage or vandalism
+- Support site through entry fees
+
+---
+
+## Academic Interest
+
+Ziwa and the Nyanga complex attract researchers for:
+- **Archaeology** - Unique architectural traditions
+- **Agricultural history** - Pre-colonial farming systems
+- **Environmental studies** - Human landscape modification
+- **Anthropology** - Community organization patterns
+
+If you're interested in research opportunities, contact:
+- University of Zimbabwe, Department of Archaeology
+- National Museums and Monuments of Zimbabwe
+- Great Zimbabwe University
+
+<Card title="A Different Kind of Heritage" icon="wheat">
+While other Zimbabwe ruins showcase royal power and elite culture, Ziwa reveals the ingenuity of ordinary people who transformed a mountainous landscape into productive farmland. It's a monument to community cooperation and agricultural innovation.
+</Card>

--- a/historic/colonial-buildings.mdx
+++ b/historic/colonial-buildings.mdx
@@ -1,0 +1,384 @@
+---
+title: "Colonial Architecture & Historic Buildings"
+description: "Explore Zimbabwe's colonial-era architectural heritage - from grand public buildings to historic hotels, churches, and railway stations"
+---
+
+# Colonial Architecture & Historic Buildings
+
+<img src="/images/historic/colonial-architecture-zimbabwe.jpg" alt="Colonial era building in Zimbabwe" />
+
+Zimbabwe's colonial period (1890-1980) left a significant architectural legacy across the country. From the grand public buildings of Harare and Bulawayo to remote mission stations and mining towns, these structures tell the story of the colonial era and its impact on Zimbabwe.
+
+<Info>
+**Context Matters** - Colonial architecture represents a complex heritage. These buildings were often built using forced labor and served systems of racial oppression. Understanding this context enriches rather than diminishes their historical significance.
+</Info>
+
+---
+
+## Harare (Salisbury)
+
+### Grand Public Buildings
+
+| Building | Year | Style | Current Use |
+|----------|------|-------|-------------|
+| **Parliament** | 1899 | Neo-classical | Parliament of Zimbabwe |
+| **High Court** | 1938 | Classical | High Court |
+| **Town House** | 1933 | Art Deco | City Council |
+| **Reserve Bank** | Various | Classical/Modern | Central Bank |
+| **National Gallery** | 1957 | Modern | Art museum |
+
+### Parliament Building
+
+<img src="/images/historic/parliament-harare.jpg" alt="Parliament Building Harare" />
+
+One of Harare's most significant colonial structures:
+
+**Features:**
+- Neo-classical design
+- Grand portico and columns
+- Still houses Parliament
+- Central Harare location
+
+**History:**
+- Built 1899
+- Originally Legislative Council
+- Expanded over time
+- Symbol of governance
+
+### Historic Hotels
+
+| Hotel | Founded | Style | Status |
+|-------|---------|-------|--------|
+| **Meikles** | 1915 | Grand Hotel | Operating |
+| **Holiday Inn (Jameson)** | 1935 | Art Deco | Operating |
+| **Monomotapa** | 1930s | Colonial | Operating |
+
+**Meikles Hotel:**
+Harare's grand dame, representing colonial-era luxury:
+- Named after the Meikle brothers (merchants)
+- Central location on Africa Unity Square
+- Historic interiors preserved
+- Afternoon tea tradition continues
+
+### Churches and Cathedrals
+
+| Church | Denomination | Year | Location |
+|--------|--------------|------|----------|
+| **Anglican Cathedral** | Anglican | 1913 | Central Harare |
+| **Roman Catholic Cathedral** | Catholic | 1914 | Harare |
+| **Dutch Reformed Church** | DRC | 1906 | Harare |
+
+### Africa Unity Square (Cecil Square)
+
+The heart of colonial Harare:
+- Laid out in 1890 by Pioneer Column
+- Originally named Cecil Square after Cecil Rhodes
+- Renamed Africa Unity Square at independence
+- Surrounded by historic buildings
+- Flower sellers, fountains, public space
+
+---
+
+## Bulawayo
+
+Bulawayo preserves more colonial architecture than any other Zimbabwean city, partly because development pressures have been lower.
+
+### Art Deco Heritage
+
+<img src="/images/historic/bulawayo-art-deco.jpg" alt="Art Deco buildings in Bulawayo" />
+
+Bulawayo has one of the finest collections of Art Deco architecture in southern Africa:
+
+**Notable Buildings:**
+- **City Hall** (1940) - Impressive Art Deco public building
+- **High Court** (1938) - Classical with Art Deco elements
+- **Haddon & Sly Building** - Commercial Art Deco
+- **Various shops on Main Street** - Period shopfronts
+
+### Railway Heritage
+
+The railway was central to Bulawayo's development:
+
+**Railway Station:**
+- Built 1901
+- One of the finest colonial stations in Africa
+- Still operational
+- Clock tower landmark
+
+**Railway Museum:**
+- Historic locomotives
+- Cecil Rhodes' private coach
+- Railway history displays
+- Engineering heritage
+
+### Historic Hotels
+
+| Hotel | Period | Notes |
+|-------|--------|-------|
+| **Bulawayo Club** | 1890s | Private club, historic |
+| **Holiday Inn** | Colonial | Historic building |
+| **Nesbitt Castle** | 1920s | Castle-style building |
+
+### Industrial Heritage
+
+- **Century Building** - Early commercial
+- **Duly's Building** - Period architecture
+- **Old Mutual Building** - Insurance company HQ
+- **Various banks** - Colonial financial architecture
+
+---
+
+## Other Towns
+
+### Masvingo (Fort Victoria)
+
+The oldest colonial settlement in Zimbabwe:
+
+**Historic Features:**
+- **Chapel Street** - Historic commercial street
+- **Original fort location** - Pioneer Column site
+- **Colonial-era courthouse** - Still standing
+- **Historic cemetery** - Pioneer graves
+
+### Gweru (Gwelo)
+
+Midlands commercial center:
+- **Colonial main street** - Period shopfronts
+- **Railway buildings** - Important junction
+- **Military heritage** - Colonial military base
+
+### Mutare (Umtali)
+
+Eastern gateway city:
+- **Main Street** - Colonial-era commercial
+- **Mutare Museum** - Regional history
+- **Churches** - Mission heritage
+- **Cecil Kop** - Named viewing point
+
+### Victoria Falls Town
+
+Tourism created unique architecture:
+- **Victoria Falls Hotel** (1904) - Colonial grand hotel
+- **Railway Station** - Historic terminus
+- **Bridge** - Engineering landmark
+
+---
+
+## The Victoria Falls Hotel
+
+<img src="/images/historic/victoria-falls-hotel.jpg" alt="Victoria Falls Hotel" />
+
+Zimbabwe's most famous colonial hotel:
+
+**History:**
+- Opened 1904
+- Built to serve railway travelers
+- Edwardian grandeur
+- Royal and celebrity guests
+
+**Features:**
+- Views to the bridge
+- Manicured gardens
+- Colonial-era interiors
+- Afternoon tea tradition
+- Museum of hotel history
+
+**Today:**
+- Still operating as luxury hotel
+- Preserved historic character
+- Popular for weddings
+- Heritage tourism draw
+
+---
+
+## Mission Stations
+
+Mission stations represent another strand of colonial-era building:
+
+### Architectural Features
+
+- **Churches** - Various styles from simple to grand
+- **Schools** - Educational buildings
+- **Hospitals** - Medical facilities
+- **Residences** - Missionary housing
+- **Cemeteries** - Historic graves
+
+### Notable Missions
+
+| Mission | Founded | Denomination | Architecture |
+|---------|---------|--------------|--------------|
+| **Inyati** | 1859 | LMS | Oldest church building |
+| **Morgenster** | 1891 | Dutch Reformed | Near Great Zimbabwe |
+| **Mt Selinda** | 1893 | UCCSA | Eastern Highlands |
+| **Waddilove** | 1892 | Methodist | Historic school |
+| **Kutama** | 1914 | Catholic | Mission complex |
+
+### Inyati Mission
+
+The oldest church building in Zimbabwe:
+- Founded by London Missionary Society
+- Robert Moffat connection
+- Historic cemetery
+- Still active
+- Can be visited
+
+---
+
+## Railway Architecture
+
+### Stations
+
+| Station | Features | Status |
+|---------|----------|--------|
+| **Bulawayo** | Grand colonial | Operating |
+| **Harare** | Large terminus | Operating |
+| **Victoria Falls** | Tourist terminus | Operating |
+| **Masvingo** | Regional | Operating |
+| **Gweru** | Junction | Operating |
+
+### The Victoria Falls Bridge
+
+<img src="/images/historic/victoria-falls-bridge.jpg" alt="Victoria Falls Bridge" />
+
+Engineering landmark opened 1905:
+
+**Features:**
+- Single-arch span
+- 128 meters long
+- 128 meters above gorge
+- Rhodes' vision realized
+- Bungee jumping site today
+
+**History:**
+- Part of "Cape to Cairo" railway dream
+- Built in England, assembled on site
+- Engineering achievement of its era
+- Cross-border connection
+
+---
+
+## Mining Town Architecture
+
+Mining created distinctive towns:
+
+### Kwekwe (Que Que)
+
+Gold mining heritage:
+- **Globe and Phoenix Mine** - Historic gold mine
+- **Mining-era buildings** - Period architecture
+- **Workers' housing** - Social history
+
+### Hwange (Wankie)
+
+Coal mining town:
+- **Colliery buildings** - Industrial heritage
+- **Railway connections** - Coal transport
+- **Company town** layout - Planned community
+
+### Shurugwi (Selukwe)
+
+Chrome mining area:
+- **Mining-era structures**
+- **Commercial buildings**
+- **Railway heritage**
+
+---
+
+## Farmhouse Architecture
+
+Colonial-era farms featured distinctive buildings:
+
+**Types:**
+- **Homesteads** - Often grand houses
+- **Tobacco barns** - Agricultural industrial
+- **Workers' compounds** - Labor housing
+- **Farm stores** - Rural commercial
+
+**Note:** Many farms are now resettled and building status varies.
+
+---
+
+## Visiting Colonial Architecture
+
+### Self-Guided Walks
+
+**Harare Walking Tour:**
+1. Start at Africa Unity Square
+2. Walk past Parliament, Town House
+3. Continue to Meikles Hotel
+4. See National Gallery
+5. End at Anglican Cathedral
+
+**Bulawayo Walking Tour:**
+1. Start at Railway Station
+2. Walk Main Street (Art Deco)
+3. Pass City Hall
+4. See Natural History Museum
+5. End at Centenary Park
+
+### Guided Options
+
+- Some hotels offer historic tours
+- Walking tour companies in Harare
+- Railway Museum in Bulawayo offers context
+- National Museums and Monuments
+
+### Photography Tips
+
+- Best light early morning or late afternoon
+- Art Deco details reward close attention
+- Include context (street scenes)
+- Some buildings may restrict photography
+- Ask permission for interiors
+
+---
+
+## Conservation Status
+
+| Category | Status |
+|----------|--------|
+| **Major public buildings** | Generally maintained |
+| **Historic hotels** | Operating, preserved |
+| **Commercial buildings** | Variable |
+| **Mission stations** | Active, mostly maintained |
+| **Railway structures** | Functional preservation |
+| **Private buildings** | Often neglected |
+
+**Challenges:**
+- Limited conservation funding
+- Economic pressures
+- Ambivalent heritage status
+- Development pressure in cities
+- Maintenance backlogs
+
+---
+
+## Understanding the Heritage
+
+### Multiple Perspectives
+
+Colonial architecture can be viewed from many angles:
+
+**As History:**
+- Documents the colonial period
+- Shows aspirations and realities
+- Preserves craftsmanship
+
+**As Critique:**
+- Built on dispossession
+- Served segregated society
+- Represents oppressive era
+
+**As Resource:**
+- Tourism asset
+- Functional buildings
+- Architectural education
+
+**As Identity:**
+- Complex relationship to present
+- Neither celebrated nor erased
+- Part of national story
+
+<Card title="Complex Heritage" icon="building">
+Colonial buildings are neither heroes nor villains - they're historical documents in stone. The grand hotels and railway stations tell stories of privilege and aspiration, while the workers' compounds nearby tell different stories entirely. Understanding both makes for richer visits.
+</Card>

--- a/historic/colonial-buildings.mdx
+++ b/historic/colonial-buildings.mdx
@@ -1,6 +1,25 @@
 ---
 title: "Colonial Architecture & Historic Buildings"
-description: "Explore Zimbabwe's colonial-era architectural heritage - from grand public buildings to historic hotels, churches, and railway stations"
+description: >-
+  Explore Zimbabwe's colonial-era architectural heritage - from grand public buildings to historic hotels, churches, and railway stations
+'og:image': 'https://travel-info.co.zw/images/hero-light.svg'
+'og:site_name': "Zimbabwe Travel Information"
+'twitter:card': "summary_large_image"
+'twitter:site': '@zimbabwetravel'
+'twitter:creator': '@zimbabwetravel'
+robots: 'index, follow'
+author: "Zimbabwe Travel Information"
+keywords: >-
+  colonial architecture zimbabwe, historic buildings harare, bulawayo art deco, victoria falls hotel, railway heritage zimbabwe, meikles hotel
+'og:description': >-
+  Zimbabwe's colonial-era architecture - grand public buildings, historic hotels, churches, and railway stations.
+'twitter:description': >-
+  Colonial architecture of Zimbabwe - historic buildings from Harare to Bulawayo.
+canonical: 'https://travel-info.co.zw/historic/colonial-buildings'
+'article:modified_time': '2025-12-30T00:00:00Z'
+'og:title': Colonial Architecture & Historic Buildings | Zimbabwe Travel Information
+'og:type': "article"
+'schema:type': "TouristDestination"
 ---
 
 # Colonial Architecture & Historic Buildings

--- a/historic/index.mdx
+++ b/historic/index.mdx
@@ -1,6 +1,25 @@
 ---
 title: "Historic Sites"
-description: "Explore Zimbabwe's rich history through its colonial heritage, liberation war sites, mission stations, and monuments that tell the story of a nation"
+description: >-
+  Explore Zimbabwe's rich history through its colonial heritage, liberation war sites, mission stations, and monuments that tell the story of a nation
+'og:image': 'https://travel-info.co.zw/images/hero-light.svg'
+'og:site_name': "Zimbabwe Travel Information"
+'twitter:card': "summary_large_image"
+'twitter:site': '@zimbabwetravel'
+'twitter:creator': '@zimbabwetravel'
+robots: 'index, follow'
+author: "Zimbabwe Travel Information"
+keywords: >-
+  zimbabwe history, colonial heritage zimbabwe, liberation war sites, heroes acre, mission stations zimbabwe, zimbabwe monuments
+'og:description': >-
+  Zimbabwe's historic sites - colonial heritage, liberation war memorials, mission stations, and national monuments.
+'twitter:description': >-
+  Historic sites of Zimbabwe - from colonial architecture to liberation war memorials.
+canonical: 'https://travel-info.co.zw/historic/index'
+'article:modified_time': '2025-12-30T00:00:00Z'
+'og:title': Historic Sites of Zimbabwe | Zimbabwe Travel Information
+'og:type': "article"
+'schema:type': "TouristDestination"
 ---
 
 # Historic Sites of Zimbabwe

--- a/historic/index.mdx
+++ b/historic/index.mdx
@@ -1,0 +1,339 @@
+---
+title: "Historic Sites"
+description: "Explore Zimbabwe's rich history through its colonial heritage, liberation war sites, mission stations, and monuments that tell the story of a nation"
+---
+
+# Historic Sites of Zimbabwe
+
+<img src="/images/historic/zimbabwe-historic-sites.jpg" alt="Historic building in Zimbabwe" />
+
+Zimbabwe's history stretches from ancient stone kingdoms to colonial occupation to hard-won independence. Beyond the famous stone ruins, the country preserves important sites from the colonial era, the liberation struggle, and the journey to nationhood.
+
+<Info>
+**Living History** - Many historic sites are still actively used, from working mission stations to government buildings. Zimbabwe's history is not just preserved - it's lived.
+</Info>
+
+---
+
+## Historical Eras
+
+### Pre-Colonial (Before 1890)
+
+| Period | Highlights |
+|--------|------------|
+| **Stone Age** | Rock art sites, early human occupation |
+| **Great Zimbabwe Era** (1100-1450) | Stone cities, gold trade |
+| **Mutapa Kingdom** (1450-1760) | Expanded empire, Portuguese contact |
+| **Rozvi Empire** (1684-1834) | Khami, Naletale, Danangombe |
+| **Ndebele Kingdom** (1838-1893) | Mzilikazi, Lobengula |
+
+### Colonial Era (1890-1980)
+
+| Period | Key Events |
+|--------|------------|
+| **Pioneer Column** (1890) | BSAC occupation begins |
+| **First Chimurenga** (1896-97) | First war of resistance |
+| **Rhodesia** (1923-1965) | Self-governing colony |
+| **UDI Period** (1965-1979) | Unilateral independence |
+| **Second Chimurenga** (1964-1979) | Liberation war |
+
+### Independence (1980-Present)
+
+| Date | Event |
+|------|-------|
+| **April 18, 1980** | Zimbabwe independence |
+| **1980s** | Nation building |
+| **2000s** | Land reform |
+| **Present** | Modern Zimbabwe |
+
+---
+
+## Colonial Heritage Sites
+
+### Harare
+
+<CardGroup cols={2}>
+  <Card title="National Archives" icon="archive">
+    Repository of national documents, photographs, and records
+  </Card>
+  <Card title="Parliament Building" icon="building-columns">
+    Neo-classical architecture, still in use
+  </Card>
+  <Card title="High Court" icon="gavel">
+    Colonial-era judicial building
+  </Card>
+  <Card title="Anglican Cathedral" icon="church">
+    Historic church in city center
+  </Card>
+</CardGroup>
+
+**Notable Historic Buildings:**
+- **Meikles Hotel** (1915) - Harare's grand dame hotel
+- **Jameson Hotel** (1935) - Art Deco landmark
+- **Town House** - City council headquarters
+- **Reserve Bank** - Colonial banking architecture
+- **National Gallery** - Cultural institution
+
+### Bulawayo
+
+Bulawayo preserves more colonial architecture than any other Zimbabwean city:
+
+| Building | Year | Significance |
+|----------|------|--------------|
+| **City Hall** | 1940 | Art Deco masterpiece |
+| **High Court** | 1938 | Colonial justice system |
+| **Chronicle Building** | 1894 | Oldest newspaper building |
+| **Railway Station** | 1901 | Historic railway terminus |
+| **National Museum** | 1901 | Natural history collection |
+
+**Railway Heritage:**
+- **Railway Museum** - Historic locomotives
+- **Station Building** - Colonial architecture
+- **Railway workshops** - Industrial heritage
+
+### Mutare
+
+- **Mutare Museum** - Regional history
+- **Historic Main Street** - Colonial shopfronts
+- **Cecil Kop** - Named for Cecil Rhodes
+
+---
+
+## Mission Stations
+
+Christian missions played significant roles in Zimbabwe's history, providing education and healthcare while also facilitating colonization.
+
+### Major Mission Stations
+
+| Mission | Founded | Denomination | Significance |
+|---------|---------|--------------|--------------|
+| **Inyati** | 1859 | LMS | Oldest church building in Zimbabwe |
+| **Hope Fountain** | 1870 | LMS | Near Bulawayo |
+| **Waddilove** | 1892 | Methodist | Important school |
+| **Kutama** | 1914 | Catholic | Mission school (Robert Mugabe's school) |
+| **Mount Selinda** | 1893 | UCCSA | Eastern Highlands mission |
+| **Morgenster** | 1891 | Dutch Reformed | Near Great Zimbabwe |
+
+### Visiting Missions
+
+Many mission stations welcome visitors:
+- Historic church buildings
+- Schools still operating
+- Archives and records
+- Graveyards with early missionary graves
+- Some offer accommodation
+
+<Tip>
+Call ahead before visiting mission stations. Many are still active religious and educational institutions, not museums.
+</Tip>
+
+---
+
+## Liberation War Sites
+
+The Second Chimurenga (1964-1979) was fought across Zimbabwe. Several sites commemorate this struggle:
+
+### Heroes' Acre (Harare)
+
+<img src="/images/historic/heroes-acre-harare.jpg" alt="Heroes Acre monument Harare" />
+
+The national shrine honoring those who died in the liberation struggle.
+
+**Features:**
+- **Tomb of the Unknown Soldier** - Central memorial
+- **Eternal Flame** - Never extinguished
+- **Murals** - Depicting the struggle
+- **Heroes' tombs** - National heroes buried here
+- **Museum** - Liberation war exhibits
+
+| | |
+|---|---|
+| **Location** | 7 km west of Harare CBD |
+| **Entry Fee** | $5 USD |
+| **Hours** | 9:00 AM - 5:00 PM |
+| **Time Needed** | 1-2 hours |
+
+### Chimoio Memorial (Mozambique Border)
+
+Commemoration of the 1977 Rhodesian attack on the ZANLA camp in Mozambique. Memorial visits can be arranged through tour operators.
+
+### Freedom Camp (Bindura)
+
+Site of a significant base during the liberation war.
+
+### Chitepo House (Lusaka, Zambia)
+
+Though in Zambia, the house where Herbert Chitepo (ZANU chairman) was assassinated in 1975 is a pilgrimage site for many Zimbabweans.
+
+---
+
+## First Chimurenga Sites (1896-1897)
+
+### Matobo Hills
+
+The Matobo Hills were central to the First Chimurenga:
+
+- **Ntumbane/Indaba Site** - Where Cecil Rhodes negotiated with Ndebele leaders
+- **Cave hideouts** - Used by resistance fighters
+- **World's View** - Cecil Rhodes burial site
+
+### Mazowe Area
+
+- **Mazowe graves** - Early settlers killed in uprising
+- **Various battle sites** - Scattered through area
+
+### Nehanda/Kaguvi Execution Site
+
+The spiritual leaders Mbuya Nehanda and Sekuru Kaguvi, who inspired the First Chimurenga, were executed in Harare (then Salisbury) in 1898. A statue of Nehanda now stands in the city.
+
+---
+
+## Pioneer Era Sites
+
+### Pioneer Trail
+
+The route taken by the Pioneer Column in 1890:
+
+| Stop | Significance |
+|------|--------------|
+| **Fort Tuli** | Entry point into Zimbabwe |
+| **Fort Victoria (Masvingo)** | First major settlement |
+| **Fort Charter** | En route camp |
+| **Fort Salisbury (Harare)** | Final destination |
+
+### Early Settler Sites
+
+- **Old Umtali** - Original Mutare location
+- **Fort Usher** - Near Chimanimani
+- **Pioneer Cemetery (Harare)** - Early settler graves
+- **Cecil Square (renamed Africa Unity Square)** - Heart of colonial Salisbury
+
+---
+
+## Industrial Heritage
+
+### Mining History
+
+Zimbabwe has a rich mining heritage:
+
+| Site | Location | Heritage |
+|------|----------|----------|
+| **Globe and Phoenix Mine** | Kwekwe | Historic gold mine |
+| **Wankie Colliery** | Hwange | Coal mining history |
+| **Selukwe Peak** | Shurugwi | Mining town |
+| **Mazowe Valley** | North of Harare | Historic citrus and gold |
+
+### Railway Heritage
+
+- **Railway Museum (Bulawayo)** - Historic locomotives
+- **Victoria Falls Bridge** - 1905 engineering marvel
+- **Beira Corridor** - Historic trade route
+
+---
+
+## Memorial Sites & Monuments
+
+### National Monuments
+
+| Monument | Location | Commemorates |
+|----------|----------|--------------|
+| **Heroes' Acre** | Harare | Liberation war |
+| **Nyadzonya Memorial** | Near Mutare | 1976 massacre |
+| **Chimoio Memorial** | Various | 1977 attack |
+| **King Lobengula Memorial** | Bulawayo | Ndebele king |
+| **Pioneer Memorial** | Harare | 1890 settlers |
+
+### Statues and Memorials
+
+- **Mbuya Nehanda Statue** (Harare) - Liberation heroine
+- **Joshua Nkomo Statue** (Bulawayo) - Father Zimbabwe
+- **Samora Machel Statue** (Harare) - Mozambican ally
+- **Lobengula Statue** (Bulawayo) - Last Ndebele king
+
+---
+
+## Historic Towns
+
+### Masvingo
+
+The oldest colonial settlement:
+- **Fort Victoria ruins** - Foundations of first fort
+- **Chapel Street** - Historic buildings
+- **Great Zimbabwe** nearby
+
+### Kwekwe
+
+Gold mining heritage:
+- **Globe and Phoenix Mine**
+- **Mining museum**
+- **Historic town center**
+
+### Rusape
+
+- **Diana's Vow rock art**
+- **Historic railway station**
+- **Colonial era buildings**
+
+---
+
+## Visiting Historic Sites
+
+### Best Approach
+
+1. **Context first** - Visit museums before sites
+2. **Hire guides** - Local knowledge enriches visits
+3. **Respect sensitivities** - Some sites are politically charged
+4. **Take time** - History can't be rushed
+
+### Recommended Museums
+
+| Museum | Location | Focus |
+|--------|----------|-------|
+| **National Museum** | Harare | Overview of national history |
+| **Natural History Museum** | Bulawayo | Pre-colonial and natural |
+| **National Archives** | Harare | Documents and photographs |
+| **Railway Museum** | Bulawayo | Transport history |
+| **Military Museum** | Gweru | Military history |
+
+---
+
+## Suggested Itinerary: Zimbabwe History Tour
+
+**Day 1-2: Harare**
+- National Museum and Archives
+- Heroes' Acre
+- Historic buildings walking tour
+- Mbuya Nehanda statue
+
+**Day 3: Masvingo**
+- Great Zimbabwe (ancient history)
+- Morgenster Mission
+- Historic town
+
+**Day 4-5: Bulawayo**
+- Natural History Museum
+- Railway Museum
+- Colonial architecture tour
+- Hope Fountain Mission
+
+**Day 6: Matobo Hills**
+- World's View (Rhodes grave)
+- Indaba site
+- Rock art
+
+**Day 7: Return**
+
+---
+
+## Conservation and Controversy
+
+Historic sites in Zimbabwe can be politically sensitive. Be aware that:
+
+- Some colonial monuments have been removed or renamed
+- Liberation war narratives may be one-sided
+- Sacred sites require cultural sensitivity
+- Photography may be restricted at some locations
+
+<Card title="Complex History" icon="book-open">
+Zimbabwe's history involves many perspectives - African kingdoms, colonial occupation, liberation struggle, and modern nation-building. The most meaningful visits engage with this complexity rather than oversimplifying.
+</Card>

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -27,11 +27,48 @@ schema:type: "Article"
   style={{ width:"100%",maxWidth:"1200px" }}
 />
 
+## Welcome to Zimbabwe
+
+**Karibu! Siyakwamukela!** Welcome to your comprehensive guide to Zimbabwe — one of Africa's most captivating and underrated destinations.
+
+Whether you're planning your first safari, seeking off-the-beaten-path adventures, or returning to explore more of what you love, **Zimbabwe Travel Information** provides the practical information, local insights, and honest guidance you need to make the most of your journey.
+
+---
+
+## How to Use This Site
+
+This guide is organized to help you find information quickly, whether you're in the early planning stages or already on the ground in Zimbabwe:
+
+<CardGroup cols="2">
+  <Card title="Heritage & History" icon="landmark" href="/heritage/unesco-world-heritage">
+    Explore Zimbabwe's UNESCO World Heritage Sites, ancient ruins, rock art, geological wonders, and scenic viewpoints. Start here to understand Zimbabwe's deep cultural and natural heritage.
+  </Card>
+  <Card title="Destinations" icon="map-location-dot" href="/destinations/provinces-regions">
+    Detailed guides to every major destination — from Victoria Falls and Hwange to the Eastern Highlands and remote wilderness areas.
+  </Card>
+  <Card title="Wildlife & Safari" icon="paw" href="/wildlife">
+    Safari planning, wildlife guides, national parks, and conservation information. Everything you need for an unforgettable wildlife experience.
+  </Card>
+  <Card title="Travel Planning" icon="clipboard-list" href="/planning/first-time-visitors">
+    Practical guides for visas, itineraries, budgeting, health, safety, and trip logistics. First-time visitors should start here.
+  </Card>
+  <Card title="Culture" icon="masks-theater" href="/culture/people-and-tribes">
+    Discover Zimbabwe's people, traditions, art, music, cuisine, and festivals. Essential context for meaningful travel.
+  </Card>
+  <Card title="Essentials" icon="circle-info" href="/essentials/visas-and-entry">
+    Quick reference for entry requirements, money, communications, distances, and practical day-to-day information.
+  </Card>
+</CardGroup>
+
+<Tip>
+  **Navigation Tip**: Use the tabs at the top to browse by category, or use the search bar to find specific topics. Each destination page links to related attractions, making it easy to plan regional itineraries.
+</Tip>
+
+---
+
 ## About This Guide
 
-**Zimbabwe Travel Information** is your definitive digital resource for exploring one of Africa's most rewarding destinations. Created by locals and travel experts who know Zimbabwe intimately, this guide exists to help you discover the authentic beauty, rich culture, and unforgettable experiences that await in this remarkable country.
-
-Whether you're planning your first safari, seeking off-the-beaten-path adventures, or returning to explore more of what you love, we provide the practical information, local insights, and honest guidance you need to make the most of your journey.
+**Zimbabwe Travel Information** is your definitive digital resource for exploring one of Africa's most rewarding destinations. Created by locals and travel experts who know Zimbabwe intimately, this guide exists to help you discover the authentic beauty, rich culture, and unforgettable experiences that await.
 
 ---
 
@@ -175,6 +212,33 @@ Tourism is one of Zimbabwe's most important industries, directly supporting cons
 </AccordionGroup>
 
 Your responsible choices help preserve Zimbabwe's natural and cultural treasures for future generations—and for future travelers who deserve to experience this country at its best.
+
+---
+
+## Explore Zimbabwe's Heritage
+
+Discover Zimbabwe's deep history beyond the famous safari destinations:
+
+<CardGroup cols="3">
+  <Card title="UNESCO World Heritage" icon="globe" href="/heritage/unesco-world-heritage">
+    Five sites of outstanding universal value including Great Zimbabwe, Victoria Falls, Mana Pools, Matobo Hills, and Khami Ruins.
+  </Card>
+  <Card title="Ancient Rock Art" icon="palette" href="/rock-art">
+    Explore 13,000 years of San rock paintings across Matobo, Mashonaland, and remote caves throughout Zimbabwe.
+  </Card>
+  <Card title="Ancient Ruins" icon="landmark" href="/heritage/khami-ruins">
+    Beyond Great Zimbabwe — discover Khami, Naletale, Dhlo-Dhlo, and the mysterious terraced structures of Nyanga.
+  </Card>
+  <Card title="Scenic Wonders" icon="mountain" href="/scenic">
+    From the 762-meter Mtarazi Falls to the dramatic Chilojo Cliffs, explore Zimbabwe's most spectacular natural viewpoints.
+  </Card>
+  <Card title="Geological Marvels" icon="gem" href="/geological">
+    Zimbabwe's famous balancing rocks, the sacred Ngomakurira Mountain, and unique rock formations found nowhere else.
+  </Card>
+  <Card title="Historic Sites" icon="building-columns" href="/historic">
+    Colonial architecture, railway heritage, and buildings that tell the story of Zimbabwe's complex modern history.
+  </Card>
+</CardGroup>
 
 ---
 

--- a/rock-art/chikupo-cave.mdx
+++ b/rock-art/chikupo-cave.mdx
@@ -1,6 +1,25 @@
 ---
 title: "Chikupo Rock Art Shelter"
-description: "Discover Chikupo Cave - home to Zimbabwe's finest formlings and exceptional trance imagery in the remote Guruve District"
+description: >-
+  Discover Chikupo Cave - home to Zimbabwe's finest formlings and exceptional trance imagery in the remote Guruve District
+'og:image': 'https://travel-info.co.zw/images/hero-light.svg'
+'og:site_name': "Zimbabwe Travel Information"
+'twitter:card': "summary_large_image"
+'twitter:site': '@zimbabwetravel'
+'twitter:creator': '@zimbabwetravel'
+robots: 'index, follow'
+author: "Zimbabwe Travel Information"
+keywords: >-
+  chikupo cave, formlings rock art, guruve rock art, trance art zimbabwe, san shamanic art, mashonaland rock paintings, rare rock art africa
+'og:description': >-
+  Chikupo Cave in Guruve - home to Zimbabwe's finest formlings and exceptional trance imagery, a rare rock art treasure.
+'twitter:description': >-
+  Chikupo Cave - Zimbabwe's finest formlings and shamanic trance imagery in remote Mashonaland.
+canonical: 'https://travel-info.co.zw/rock-art/chikupo-cave'
+'article:modified_time': '2025-12-30T00:00:00Z'
+'og:title': Chikupo Rock Art Shelter | Zimbabwe Travel Information
+'og:type': "article"
+'schema:type': "TouristDestination"
 ---
 
 # Chikupo Rock Art Shelter

--- a/rock-art/chikupo-cave.mdx
+++ b/rock-art/chikupo-cave.mdx
@@ -1,0 +1,303 @@
+---
+title: "Chikupo Rock Art Shelter"
+description: "Discover Chikupo Cave - home to Zimbabwe's finest formlings and exceptional trance imagery in the remote Guruve District"
+---
+
+# Chikupo Rock Art Shelter
+
+<img src="/images/rock-art/chikupo-formlings.jpg" alt="Chikupo Cave formlings rock art" />
+
+**Chikupo Rock Art Shelter** in Mashonaland Central is one of Zimbabwe's most significant rock art sites, famous for its exceptional **formlings** - mysterious oval shapes that appear almost nowhere else in southern African rock art. For researchers and serious rock art enthusiasts, Chikupo is essential.
+
+---
+
+## Quick Facts
+
+| | |
+|---|---|
+| **Location** | Guruve District, Mashonaland Central |
+| **Distance from Harare** | ~150 km |
+| **Known For** | Finest formlings in Zimbabwe |
+| **Access** | Remote, 4x4 recommended |
+| **Permission** | Required from NMMZ |
+| **Difficulty** | Moderate hike to site |
+
+---
+
+## The Formlings
+
+### What Are Formlings?
+
+Formlings are enigmatic oval or kidney-shaped painted forms:
+- Outlined shapes with internal patterns
+- Found almost exclusively in this region
+- Among the most debated images in rock art
+- Exceptional examples at Chikupo
+
+### What Do They Mean?
+
+Researchers have proposed various interpretations:
+
+| Theory | Explanation |
+|--------|-------------|
+| **Bee swarms/Honeycombs** | Resemblance to hive structures |
+| **Entoptic phenomena** | Patterns seen during trance |
+| **Body maps** | Symbolic representations of the body |
+| **Spiritual concepts** | Unknown religious imagery |
+| **Animal forms** | Abstracted creatures |
+
+The most widely accepted view connects them to **shamanic trance experiences**, where the shapes represent visions seen in altered states of consciousness.
+
+### Why Chikupo is Special
+
+Chikupo has:
+- Multiple formlings in one shelter
+- Exceptional preservation
+- Associated trance imagery
+- Clear painting context
+- Research documentation
+
+---
+
+## Other Paintings
+
+Beyond the formlings, Chikupo features:
+
+### Trance Imagery
+
+Classic San trance art elements:
+- Figures in bending postures
+- Lines from heads/noses (nasal bleeding)
+- Transformation scenes
+- Entoptic patterns
+
+### Animals
+
+- Kudu and other antelope
+- Various fauna
+- Associated with human figures
+- Hunting scenes
+
+### Human Figures
+
+- Dancers
+- Hunters
+- Trance healers
+- Group scenes
+
+---
+
+## The Setting
+
+### Physical Description
+
+- Large rock overhang
+- Protected from elements
+- Smooth painting surface
+- Remote, atmospheric location
+- Natural granite setting
+
+### Landscape
+
+The Guruve area offers:
+- Rolling granite hills
+- Miombo woodland
+- Remote, wild feeling
+- Few other visitors
+- Traditional rural communities
+
+---
+
+## Getting There
+
+### Route from Harare
+
+1. Head north toward Bindura (80 km)
+2. Continue to Mvurwi
+3. Proceed to Guruve District
+4. Local directions required for final approach
+5. 4x4 essential for last section
+
+**Total Distance:** ~150 km
+**Total Time:** 3-4 hours (road conditions variable)
+
+### Access Requirements
+
+| Requirement | Details |
+|-------------|---------|
+| **Permission** | Contact NMMZ in advance |
+| **Guide** | Essential (local knowledge) |
+| **Vehicle** | 4x4 recommended |
+| **Timing** | Full day trip from Harare |
+
+### NMMZ Contact
+
+Contact the National Museums and Monuments of Zimbabwe:
+- Request access permission
+- Arrange local guide
+- Get current directions
+- Allow 1-2 weeks for arrangements
+
+---
+
+## Planning Your Visit
+
+### What to Bring
+
+**Essential:**
+- 4x4 vehicle (or arrange transport)
+- Full tank of fuel (limited stations)
+- Food and water for the day
+- Sun protection
+- Good walking shoes
+
+**Recommended:**
+- Camera with telephoto
+- Binoculars
+- GPS device
+- First aid kit
+- Warm layer (highlands cool)
+
+### Best Season
+
+| Season | Conditions |
+|--------|------------|
+| **May-Oct (Dry)** | Best access, clear skies |
+| **Nov-Apr (Wet)** | Roads may be impassable |
+
+### Time Required
+
+- **Travel from Harare:** 3-4 hours each way
+- **At site:** 1-2 hours
+- **Total day:** Full day trip
+- **Alternative:** Overnight in Guruve area
+
+---
+
+## Photography
+
+### Opportunities
+
+Chikupo offers excellent photographic subjects:
+- Unique formlings (found almost nowhere else)
+- Trance scenes
+- Wide shelter views
+- Remote landscape
+
+### Tips
+
+- **Telephoto lens** essential (can't get close)
+- **Tripod** for low-light cave interior
+- **No flash** (damages pigments)
+- **Polarizing filter** reduces rock glare
+- **Document formlings** in detail
+
+---
+
+## Academic Interest
+
+### For Researchers
+
+Chikupo is significant for:
+- Formling studies
+- Trance art research
+- Regional distribution patterns
+- Stylistic analysis
+- Dating possibilities
+
+### Key Publications
+
+Chikupo features in academic literature on:
+- San rock art interpretation
+- Formling distribution
+- Mashonaland rock art
+- Southern African archaeology
+
+### Research Access
+
+Serious researchers should:
+- Contact NMMZ
+- University of Zimbabwe archaeology department
+- Rock Art Research Institute
+- Submit research proposals
+
+---
+
+## Combining Sites
+
+### Mashonaland Rock Art Expedition
+
+**Day 1:**
+- Harare to Guruve area
+- Chikupo Cave
+
+**Day 2:**
+- Zombepata (another formling site)
+- Return to Harare
+
+**Day 3:**
+- Domboshava (accessible comparison)
+
+### Comparison Sites
+
+| Site | Formlings? | Access | Other Highlights |
+|------|------------|--------|------------------|
+| **Chikupo** | Exceptional | Difficult | Trance imagery |
+| **Zombepata** | Excellent | Difficult | Rare animal subjects |
+| **Domboshava** | No | Easy | General rock art |
+| **Matobo** | No | Easy | Quantity, variety |
+
+---
+
+## Conservation
+
+### Site Condition
+
+- Remote location provides protection
+- Limited visitor numbers
+- Natural weathering ongoing
+- Some fading over time
+
+### Threats
+
+| Threat | Level |
+|--------|-------|
+| Vandalism | Low (remote) |
+| Development | Low |
+| Natural weathering | Moderate |
+| Fire | Moderate |
+
+### Preservation
+
+- NMMZ oversight
+- Controlled access
+- Research documentation
+- Community awareness
+
+---
+
+## Why Make the Effort?
+
+Chikupo requires planning and a challenging journey. Why bother?
+
+**For Rock Art Enthusiasts:**
+- Formlings are almost unique to this region
+- Essential for understanding San art diversity
+- Exceptional preservation and quality
+- Fewer than 100 visitors per year
+
+**For Adventurous Travelers:**
+- Remote, authentic experience
+- Off the tourist trail
+- Connect with rural Zimbabwe
+- Serious bragging rights
+
+**For Researchers:**
+- Primary formling site
+- Essential field experience
+- Publishable opportunities
+- Original documentation possible
+
+<Card title="Worth the Journey" icon="route">
+Chikupo isn't for everyone - the access is challenging and requires planning. But for those fascinated by rock art and willing to make the effort, this is one of Africa's most significant and least-visited painted sites. The formlings here pose questions that researchers are still trying to answer.
+</Card>

--- a/rock-art/index.mdx
+++ b/rock-art/index.mdx
@@ -1,6 +1,25 @@
 ---
 title: "Rock Art of Zimbabwe"
-description: "Explore Zimbabwe's extraordinary rock art heritage - thousands of San paintings spanning 13,000 years hidden in caves and rock shelters across the country"
+description: >-
+  Explore Zimbabwe's extraordinary rock art heritage - thousands of San paintings spanning 13,000 years hidden in caves and rock shelters across the country
+'og:image': 'https://travel-info.co.zw/images/hero-light.svg'
+'og:site_name': "Zimbabwe Travel Information"
+'twitter:card': "summary_large_image"
+'twitter:site': '@zimbabwetravel'
+'twitter:creator': '@zimbabwetravel'
+robots: 'index, follow'
+author: "Zimbabwe Travel Information"
+keywords: >-
+  zimbabwe rock art, san bushman paintings, matobo rock art, cave paintings zimbabwe, prehistoric art africa, rock paintings zimbabwe, nswatugi, domboshava rock art
+'og:description': >-
+  Discover Zimbabwe's extraordinary rock art heritage - thousands of San paintings spanning 13,000 years in caves across the country.
+'twitter:description': >-
+  Zimbabwe's rock art heritage - thousands of ancient San paintings hidden in caves and rock shelters.
+canonical: 'https://travel-info.co.zw/rock-art/index'
+'article:modified_time': '2025-12-30T00:00:00Z'
+'og:title': Rock Art of Zimbabwe | Zimbabwe Travel Information
+'og:type': "article"
+'schema:type': "TouristDestination"
 ---
 
 # Rock Art of Zimbabwe

--- a/rock-art/index.mdx
+++ b/rock-art/index.mdx
@@ -1,0 +1,324 @@
+---
+title: "Rock Art of Zimbabwe"
+description: "Explore Zimbabwe's extraordinary rock art heritage - thousands of San paintings spanning 13,000 years hidden in caves and rock shelters across the country"
+---
+
+# Rock Art of Zimbabwe
+
+<img src="/images/rock-art/zimbabwe-rock-art-main.jpg" alt="San rock art painting Zimbabwe" />
+
+Zimbabwe possesses one of the **richest concentrations of rock art in the world**. Thousands of painted sites scattered across the country preserve a visual record spanning at least 13,000 years, created primarily by the San (Bushmen) hunter-gatherers who once inhabited this region.
+
+<Info>
+**World-Class Heritage** - The Matobo Hills alone contains over 3,000 documented rock art sites, earning it UNESCO World Heritage status partly for this extraordinary concentration of ancient paintings.
+</Info>
+
+---
+
+## Overview
+
+### By the Numbers
+
+| | |
+|---|---|
+| **Total Documented Sites** | 3,000+ (many more undiscovered) |
+| **Age Range** | 13,000+ years to ~200 years ago |
+| **Primary Creators** | San (Bushmen/Basarwa) people |
+| **Highest Concentration** | Matobo Hills |
+| **UNESCO Recognition** | Matobo Hills (2003) |
+
+### Geographic Distribution
+
+Rock art is found throughout Zimbabwe, but major concentrations exist in:
+
+1. **Matobo Hills** (Matabeleland South) - Densest concentration
+2. **Mashonaland Central** - Including Guruve and Mvurwi areas
+3. **Harare Region** - Domboshava, Ngomakurira
+4. **Eastern Highlands** - Scattered sites
+5. **Midlands** - Various locations
+
+---
+
+## The Artists: San People
+
+### Who Were the San?
+
+The San (also known as Bushmen or Basarwa) were the original inhabitants of southern Africa, living as hunter-gatherers for thousands of years before Bantu-speaking peoples arrived.
+
+**San Society:**
+- Egalitarian social structure
+- Nomadic hunter-gatherer lifestyle
+- Rich spiritual traditions
+- Deep knowledge of the natural world
+- Trance healing practices central to spiritual life
+
+### Why Did They Paint?
+
+The paintings were not merely decorative - they were deeply spiritual:
+
+| Theory | Explanation |
+|--------|-------------|
+| **Trance/Shamanic** | Paintings record visions seen during healing trances |
+| **Power Capture** | Capturing the spiritual power of animals |
+| **Teaching** | Recording knowledge for future generations |
+| **Ritual** | Part of rain-making and other ceremonies |
+| **Narrative** | Recording important events and experiences |
+
+The most widely accepted explanation is that many paintings depict **shamanic trance experiences**, with the geometric patterns (entoptics) and supernatural scenes representing visions experienced during altered states of consciousness.
+
+---
+
+## What You'll See
+
+### Common Subjects
+
+**Animals:**
+- Kudu (most common)
+- Eland (spiritually significant)
+- Giraffe
+- Elephant
+- Zebra
+- Various antelope species
+- Predators (lion, leopard)
+- Baboons
+- Birds
+
+**Human Figures:**
+- Hunters with bows
+- Dancing figures
+- Figures in trance postures
+- Ritual scenes
+- Hand prints
+
+**Supernatural Elements:**
+- Therianthropes (human-animal hybrids)
+- Geometric patterns (entoptics)
+- Rain animals
+- Lines and dots
+
+### Artistic Techniques
+
+The San artists demonstrated remarkable skill:
+
+| Technique | Description |
+|-----------|-------------|
+| **Pigments** | Red/brown (iron oxide), white (bird droppings, clay), black (charcoal, manganese) |
+| **Binding** | Animal fat, blood, plant materials |
+| **Application** | Fingers, sticks, brushes, feathers |
+| **Shading** | Sophisticated use of multiple colors |
+| **Perspective** | Various viewing angles depicted |
+
+---
+
+## Where to See Rock Art
+
+### Matobo Hills (Best)
+
+<Card title="Matobo Hills" icon="mountain" href="/destinations/matobo-hills">
+Home to over 3,000 documented sites - the world's highest concentration of rock art.
+</Card>
+
+**Key Sites:**
+| Site | Highlights | Access |
+|------|------------|--------|
+| **Nswatugi Cave** | Giraffes, kudu, human figures | Easy walk |
+| **Pomongwe Cave** | One of the oldest sites (40,000 years human occupation) | Easy |
+| **Bambata Cave** | Gave name to a Stone Age culture | Moderate |
+| **Silozwane Cave** | Excellent paintings | Guided tour |
+| **White Rhino Shelter** | Well-preserved art | NMMZ guided |
+
+### Mashonaland Sites
+
+| Site | Location | Highlights |
+|------|----------|------------|
+| **Domboshava** | 30 km from Harare | Accessible, good paintings |
+| **Ngomakurira** | 40 km from Harare | Rock art + mountain views |
+| **Chikupo** | Mashonaland Central | Exceptional formlings |
+| **Zombepata** | Guruve area | Rare subjects (porcupine, ostrich) |
+| **Thetford** | Mashonaland Central | Pristine paint quality |
+
+### Eastern Highlands
+
+| Site | Location | Notes |
+|------|----------|-------|
+| **Diana's Vow** | Rusape area | Small but significant |
+| **Makumbe Cave** | Near Mutare | Remote, atmospheric |
+| **Nyanga area** | Various | Combined with Ziwa ruins |
+
+---
+
+## Featured Sites
+
+### Domboshava
+
+<Card title="Domboshava" icon="palette" href="/destinations/domboshava">
+Just 30 km from Harare - the most accessible major rock art site in Zimbabwe.
+</Card>
+
+**Highlights:**
+- Easy day trip from Harare
+- Well-maintained walkways and signage
+- Multiple painted shelters
+- Beautiful granite scenery
+- On-site interpretation center
+
+### Nswatugi Cave
+
+Located in Matobo National Park, Nswatugi is one of the most impressive rock art galleries in Africa.
+
+**What to see:**
+- Life-sized giraffe paintings
+- Kudu in various poses
+- Human figures hunting
+- Excellent preservation
+- Stunning cave setting
+
+### Pomongwe Cave
+
+One of the most archaeologically significant sites, with evidence of human occupation spanning 40,000 years.
+
+**Features:**
+- Rock paintings from multiple periods
+- Archaeological excavation site
+- Stone tools found here
+- Evidence of climate change adaptations
+
+---
+
+## Viewing Tips
+
+### Best Practices
+
+1. **Hire a guide** - They know where the best paintings are
+2. **Visit in the morning** - Better light for viewing and photography
+3. **Look carefully** - Many paintings are faded and easy to miss
+4. **Take your time** - Layers of paintings reward patience
+5. **Bring binoculars** - Useful for paintings high on walls
+
+### Photography
+
+- Natural light only (no flash)
+- Polarizing filter helps reduce glare
+- Best light: morning or overcast days
+- Telephoto lens for details
+- Wide angle for context
+
+### Conservation Do's and Don'ts
+
+**DO:**
+- Stay on paths
+- Keep distance from paintings
+- Use zoom lenses
+- Report damage
+- Support sites through entry fees
+
+**DON'T:**
+- Touch the art
+- Use flash photography
+- Splash water on paintings
+- Remove anything
+- Mark or graffiti the rocks
+
+<Warning>
+Rock art is extremely fragile. Touching paintings - even lightly - damages them. The oils from human skin accelerate deterioration. Please keep your hands off all rock art surfaces.
+</Warning>
+
+---
+
+## Understanding the Paintings
+
+### Common Motifs Explained
+
+| Motif | Possible Meaning |
+|-------|------------------|
+| **Eland** | Most spiritually powerful animal; associated with trance |
+| **Lines from head/nose** | Trance bleeding (nasal hemorrhage during trance) |
+| **Bending figures** | Trance posture |
+| **Half-human/half-animal** | Shaman transforming during trance |
+| **Geometric patterns** | Entoptic phenomena (seen during trance) |
+| **Hand prints** | Marking presence, spiritual connection |
+
+### Reading a Rock Art Panel
+
+1. **Look for layers** - Older paintings often underneath newer
+2. **Note relationships** - Figures interacting tell stories
+3. **Observe postures** - Body positions have meaning
+4. **Check for superimposition** - Later paintings over earlier
+5. **Consider location** - Why this shelter? What view?
+
+---
+
+## Research and Conservation
+
+### Ongoing Work
+
+Organizations protecting Zimbabwe's rock art:
+
+- **National Museums and Monuments of Zimbabwe (NMMZ)** - Official custodians
+- **Rock Art Research Institute** - Academic research
+- **Trust for African Rock Art** - Conservation advocacy
+- **Universities** - Archaeological studies
+
+### Threats to Rock Art
+
+| Threat | Impact |
+|--------|--------|
+| Natural weathering | Gradual fading and flaking |
+| Water damage | Paint dissolution and rock exfoliation |
+| Vandalism | Graffiti, touching, damage |
+| Development | Quarrying, construction near sites |
+| Fire | Smoke damage and heat spalling |
+| Neglect | Lack of protection and maintenance |
+
+---
+
+## Planning Your Rock Art Visit
+
+### Suggested Itineraries
+
+**Day Trip from Harare:**
+- Domboshava (half day)
+- Or Ngomakurira (full day with hiking)
+
+**Weekend from Bulawayo:**
+- Day 1: Matobo Hills (Nswatugi, Pomongwe)
+- Day 2: More Matobo sites + World's View
+
+**Extended Rock Art Tour:**
+- Day 1-2: Matobo Hills (multiple sites)
+- Day 3: Travel to Mashonaland Central
+- Day 4: Chikupo, Zombepata area
+- Day 5: Domboshava, return to Harare
+
+---
+
+## Practical Information
+
+### Entry Fees (Approximate)
+
+| Site | Fee (USD) |
+|------|-----------|
+| Domboshava | $10 |
+| Matobo National Park | $15 (includes multiple sites) |
+| NMMZ-managed sites | $5-10 |
+
+### Guides
+
+Guides are highly recommended:
+- Know exact painting locations
+- Explain cultural context
+- Ensure you don't miss anything
+- Available at major sites or through tour operators
+
+### What to Bring
+
+- Comfortable walking shoes
+- Sun protection
+- Water
+- Binoculars
+- Camera with zoom lens
+- Notebook for observations
+
+<Card title="Living Heritage" icon="hand-holding-heart">
+Rock art sites are still sacred to some communities. Approach with respect, as you would any place of spiritual significance. You're not just viewing art - you're connecting with tens of thousands of years of human experience.
+</Card>

--- a/rock-art/mashonaland-sites.mdx
+++ b/rock-art/mashonaland-sites.mdx
@@ -1,6 +1,25 @@
 ---
 title: "Mashonaland Rock Art Sites"
-description: "Explore the exceptional rock art of Mashonaland - from Domboshava near Harare to the extraordinary painted caves of Guruve and Mvurwi"
+description: >-
+  Explore the exceptional rock art of Mashonaland - from Domboshava near Harare to the extraordinary painted caves of Guruve and Mvurwi
+'og:image': 'https://travel-info.co.zw/images/hero-light.svg'
+'og:site_name': "Zimbabwe Travel Information"
+'twitter:card': "summary_large_image"
+'twitter:site': '@zimbabwetravel'
+'twitter:creator': '@zimbabwetravel'
+robots: 'index, follow'
+author: "Zimbabwe Travel Information"
+keywords: >-
+  mashonaland rock art, domboshava, guruve caves, rock paintings harare, san art mashonaland, cave paintings near harare, zimbabwe rock art sites
+'og:description': >-
+  Mashonaland rock art sites - from accessible Domboshava to exceptional caves in Guruve and Mvurwi.
+'twitter:description': >-
+  Mashonaland rock art - exceptional San paintings from Domboshava near Harare to remote Guruve caves.
+canonical: 'https://travel-info.co.zw/rock-art/mashonaland-sites'
+'article:modified_time': '2025-12-30T00:00:00Z'
+'og:title': Mashonaland Rock Art Sites | Zimbabwe Travel Information
+'og:type': "article"
+'schema:type': "TouristDestination"
 ---
 
 # Mashonaland Rock Art Sites

--- a/rock-art/mashonaland-sites.mdx
+++ b/rock-art/mashonaland-sites.mdx
@@ -1,0 +1,282 @@
+---
+title: "Mashonaland Rock Art Sites"
+description: "Explore the exceptional rock art of Mashonaland - from Domboshava near Harare to the extraordinary painted caves of Guruve and Mvurwi"
+---
+
+# Mashonaland Rock Art Sites
+
+<img src="/images/rock-art/mashonaland-rock-art.jpg" alt="Rock art in Mashonaland caves" />
+
+The Mashonaland provinces contain dozens of significant rock art sites, from easily accessible caves near Harare to remote treasures in the northern districts. These sites complement the famous Matobo collection, often featuring unique subjects and exceptional preservation.
+
+---
+
+## Overview
+
+### Distribution
+
+| Province | Notable Sites | Accessibility |
+|----------|---------------|---------------|
+| **Harare Area** | Domboshava, Ngomakurira, Lake Chivero | Easy |
+| **Mashonaland Central** | Chikupo, Zombepata, Thetford | Moderate-Difficult |
+| **Mashonaland East** | Various smaller sites | Variable |
+| **Mashonaland West** | Lake Chivero area, Chinhoyi | Easy-Moderate |
+
+---
+
+## Major Sites
+
+### Domboshava
+
+The most accessible major rock art site in Zimbabwe.
+
+| | |
+|---|---|
+| **Location** | 30 km north of Harare |
+| **Access** | Easy - paved road, short walks |
+| **Highlights** | Multiple painted shelters, granite dome |
+| **Time Needed** | 2-4 hours |
+
+[Full Domboshava Guide →](/destinations/domboshava)
+
+---
+
+### Chikupo Rock Art Shelter
+
+<img src="/images/rock-art/chikupo-cave.jpg" alt="Chikupo rock art shelter" />
+
+One of Zimbabwe's most exceptional rock art sites, featuring rare "formlings" - enigmatic shapes thought to represent shamanic visions.
+
+**What Makes Chikupo Special:**
+- **Formlings** - Rare oval/kidney-shaped forms found almost nowhere else
+- **Trance imagery** - Classic depictions of shamanic transformation
+- **Superimposition** - Multiple layers spanning thousands of years
+- **Preservation** - Protected overhang keeps paintings vivid
+
+**The Formlings:**
+These mysterious shapes are among the most debated images in southern African rock art:
+- Oval or kidney-shaped outlines
+- Often with internal patterns
+- May represent:
+  - Bee swarms/honeycombs
+  - Entoptic phenomena (trance visions)
+  - Body maps
+  - Unknown spiritual concepts
+
+| | |
+|---|---|
+| **Location** | Guruve District, Mashonaland Central |
+| **Access** | Remote - 4x4 recommended |
+| **Guide** | Essential |
+| **Permission** | Required from NMMZ |
+| **Time** | Full day trip from Harare |
+
+---
+
+### Zombepata Cave
+
+<img src="/images/rock-art/zombepata.jpg" alt="Zombepata cave paintings" />
+
+Home to some of the finest and most unusual rock art in Zimbabwe.
+
+**Exceptional Features:**
+- **Best formlings in Zimbabwe** - Multiple examples
+- **Rare animal subjects:**
+  - Porcupines (very unusual in rock art)
+  - Ostriches
+  - White zebras
+  - Female kudu (usually males depicted)
+- **Birds in brown and white** - Uncommon coloring
+- **Excellent preservation**
+
+**Art Details:**
+
+| Subject | Notes |
+|---------|-------|
+| **Formlings** | Among the finest examples known |
+| **Kudu** | Including rare female depictions |
+| **Porcupine** | Extremely rare - one of few known |
+| **Ostrich** | Unusual for this region |
+| **Human figures** | In various poses |
+
+| | |
+|---|---|
+| **Location** | Guruve District, north of Harare |
+| **Access** | Remote, requires planning |
+| **Distance from Harare** | ~150 km |
+| **Difficulty** | Moderate hike to site |
+| **Permission** | Check with NMMZ |
+
+---
+
+### Thetford Game Reserve Rock Art
+
+A remarkable site known for:
+- **Pristine paint quality** - Among the best-preserved in Zimbabwe
+- **Innovative composition** - Artists used natural rock features
+- **Trance scene** - First known use of rock surface in composition
+- **Game reserve setting** - Combined wildlife and rock art
+
+**Unique Features:**
+The Thetford paintings are notable because the San artists deliberately incorporated a natural physical feature of the granite rock surface into their trance scene composition - a technique rarely documented elsewhere.
+
+| | |
+|---|---|
+| **Location** | Thetford Game Reserve, Mashonaland Central |
+| **Access** | Through game reserve |
+| **Permission** | Contact reserve management |
+| **Combined With** | Wildlife viewing |
+
+---
+
+### Lake Chivero Rock Art
+
+The shores and hills around Lake Chivero contain several rock art sites:
+
+**Sites Include:**
+- Cave paintings on granite kopjes
+- Shelters overlooking the lake
+- Combined with wildlife viewing opportunities
+
+**Advantages:**
+- Easy day trip from Harare
+- Combine with game viewing
+- Multiple sites in one area
+- Good facilities at Lake Chivero Recreational Park
+
+[Explore Lake Chivero →](/destinations/lake-chivero)
+
+---
+
+### Ngomakurira
+
+The sacred mountain also contains rock art:
+
+- Multiple painted shelters
+- Combined with spectacular geology
+- Challenging but rewarding hike
+- Drum rocks and spiritual significance
+
+[Full Ngomakurira Guide →](/geological/ngomakurira)
+
+---
+
+## Minor Sites
+
+### Diana's Vow (Rusape Area)
+
+A small but significant site near Rusape featuring:
+- Well-preserved paintings
+- Accessible location
+- Historical research importance
+- Named after early researcher
+
+### Makumbe Cave (Mutare Area)
+
+Remote cave with:
+- Good paintings
+- Atmospheric setting
+- Challenging access
+- Requires local guide
+
+### Nyangwe Fort Area
+
+In the Eastern Highlands:
+- Rock art combined with Nyanga ruins
+- Part of broader Nyanga heritage complex
+- Multiple sites in scenic highlands
+
+---
+
+## Planning Your Visit
+
+### Accessibility Guide
+
+| Site | From Harare | Road Type | Difficulty | Guide Needed |
+|------|-------------|-----------|------------|--------------|
+| Domboshava | 30 km | Tar | Easy | Recommended |
+| Ngomakurira | 40 km | Tar + dirt | Moderate | Recommended |
+| Lake Chivero | 35 km | Tar | Easy | Optional |
+| Chikupo | 150 km | Tar + rough | Difficult | Essential |
+| Zombepata | 150 km | Tar + rough | Difficult | Essential |
+| Thetford | 120 km | Tar + reserve | Moderate | Required |
+
+### Suggested Itineraries
+
+**Day Trip from Harare:**
+- Domboshava or Lake Chivero rock art
+- Easy, no special arrangements needed
+
+**Weekend Rock Art Tour:**
+- Day 1: Domboshava morning, Ngomakurira afternoon
+- Day 2: Lake Chivero area sites
+
+**Extended Rock Art Expedition:**
+- Day 1: Harare to Guruve area
+- Day 2: Chikupo and Zombepata (with guide)
+- Day 3: Thetford Game Reserve
+- Day 4: Return via Domboshava
+
+### Permissions and Guides
+
+**Easy Access Sites (no permission needed):**
+- Domboshava
+- Ngomakurira
+- Lake Chivero
+
+**Permission Required:**
+- Chikupo - Contact NMMZ
+- Zombepata - Contact NMMZ
+- Thetford - Contact reserve
+- Private land sites - Ask locally
+
+**How to Arrange:**
+1. Contact National Museums and Monuments of Zimbabwe (NMMZ)
+2. Allow 1-2 weeks for arrangements
+3. Guides can often be arranged through NMMZ
+4. Local tour operators may assist
+
+---
+
+## Conservation Notes
+
+Mashonaland rock art faces several threats:
+
+| Threat | Status | Impact |
+|--------|--------|--------|
+| **Vandalism** | Moderate | Graffiti at accessible sites |
+| **Development** | Low | Rural areas largely undeveloped |
+| **Farming** | Low | Some sites on farmland |
+| **Weather** | Ongoing | Natural deterioration |
+| **Fire** | Moderate | Bush fires damage sites |
+
+**How You Can Help:**
+- Report vandalism to NMMZ
+- Don't touch paintings
+- Support guide employment
+- Share site locations responsibly
+- Pay entrance fees
+
+---
+
+## Comparing Regions
+
+| Factor | Mashonaland | Matobo Hills |
+|--------|-------------|--------------|
+| **Number of Sites** | Dozens | 3,000+ |
+| **Density** | Scattered | Concentrated |
+| **Access** | Variable | Mostly easy |
+| **Unique Features** | Formlings | Sheer quantity |
+| **Tourism** | Low | Established |
+| **Crowds** | Rare | Can be busy |
+
+**Why Visit Mashonaland:**
+- Unique subjects (formlings, rare animals)
+- Fewer tourists
+- Close to Harare
+- Exceptional preservation at some sites
+- Different character from Matobo
+
+<Card title="Hidden Treasures" icon="gem">
+While Matobo gets the UNESCO recognition, Mashonaland's rock art sites offer unique experiences you won't find elsewhere. The formlings at Chikupo and Zombepata are among the most mysterious images in African rock art - worth the extra effort to see.
+</Card>

--- a/rock-art/matobo-rock-art.mdx
+++ b/rock-art/matobo-rock-art.mdx
@@ -1,6 +1,25 @@
 ---
 title: "Matobo Hills Rock Art"
-description: "Explore the world's highest concentration of rock art in the Matobo Hills - over 3,000 sites spanning 13,000 years of San artistic tradition"
+description: >-
+  Explore the world's highest concentration of rock art in the Matobo Hills - over 3,000 sites spanning 13,000 years of San artistic tradition
+'og:image': 'https://travel-info.co.zw/images/hero-light.svg'
+'og:site_name': "Zimbabwe Travel Information"
+'twitter:card': "summary_large_image"
+'twitter:site': '@zimbabwetravel'
+'twitter:creator': '@zimbabwetravel'
+robots: 'index, follow'
+author: "Zimbabwe Travel Information"
+keywords: >-
+  matobo rock art, matopos cave paintings, san rock art matobo, nswatugi cave, pomongwe cave, bushman paintings zimbabwe, unesco matobo, rock art sites bulawayo
+'og:description': >-
+  Matobo Hills rock art - the world's highest concentration with over 3,000 painted sites spanning 13,000 years.
+'twitter:description': >-
+  Matobo Hills rock art - world's highest concentration of San paintings, UNESCO World Heritage Site.
+canonical: 'https://travel-info.co.zw/rock-art/matobo-rock-art'
+'article:modified_time': '2025-12-30T00:00:00Z'
+'og:title': Matobo Hills Rock Art | Zimbabwe Travel Information
+'og:type': "article"
+'schema:type': "TouristDestination"
 ---
 
 # Matobo Hills Rock Art

--- a/rock-art/matobo-rock-art.mdx
+++ b/rock-art/matobo-rock-art.mdx
@@ -1,0 +1,341 @@
+---
+title: "Matobo Hills Rock Art"
+description: "Explore the world's highest concentration of rock art in the Matobo Hills - over 3,000 sites spanning 13,000 years of San artistic tradition"
+---
+
+# Matobo Hills Rock Art
+
+<img src="/images/rock-art/matobo-hills-paintings.jpg" alt="San rock paintings in Matobo Hills" />
+
+The Matobo Hills contain the **highest concentration of rock art in the world**, with over 3,000 documented painted sites. This extraordinary gallery of San (Bushmen) art was one of the key reasons for the Matobo's inscription as a UNESCO World Heritage Site in 2003.
+
+<Info>
+**UNESCO Recognition** - The Matobo Hills were inscribed as a World Heritage Site partly because they "contain outstanding collections of rock art and the large number of rock art sites in a comparatively small area makes the hills an exceptional repository of the artistic tradition."
+</Info>
+
+---
+
+## Overview
+
+### Key Statistics
+
+| | |
+|---|---|
+| **Number of Sites** | 3,000+ documented |
+| **Age Range** | 13,000 years to ~200 years ago |
+| **Artists** | San (Bushmen/Basarwa) peoples |
+| **Density** | Highest in the world |
+| **Protected Since** | 1926 (National Park) |
+| **UNESCO Status** | World Heritage Site (2003) |
+
+### Why Matobo is Special
+
+1. **Sheer Numbers** - More sites per square kilometer than anywhere else
+2. **Diversity** - Wide range of subjects and styles
+3. **Preservation** - Many paintings remarkably intact
+4. **Accessibility** - Several sites open to visitors
+5. **Setting** - Dramatic granite landscape adds atmosphere
+
+---
+
+## What You'll See
+
+### Animals
+
+The San painted the animals they hunted, feared, and revered:
+
+| Animal | Frequency | Significance |
+|--------|-----------|--------------|
+| **Kudu** | Very common | Elegant, spiritual importance |
+| **Giraffe** | Common | Striking images at Nswatugi |
+| **Eland** | Common | Most spiritually powerful animal |
+| **Zebra** | Occasional | Distinctive stripes depicted |
+| **Elephant** | Occasional | Power and memory |
+| **Rhino** | Rare | Now locally extinct |
+| **Lion** | Rare | Feared predator |
+| **Baboon** | Common | Social parallels |
+
+### Human Figures
+
+- **Hunters** with bows and arrows
+- **Dancing figures** in ritual poses
+- **Running figures** in hunting scenes
+- **Figures in trance** (bending postures)
+- **Shamans/healers** in transformation
+
+### Spiritual and Symbolic
+
+| Motif | Interpretation |
+|-------|----------------|
+| **Therianthropes** | Part human, part animal - shamanic transformation |
+| **Dotted lines** | Entoptic phenomena (trance visions) |
+| **Hand prints** | Presence, contact with rock |
+| **Rain animals** | Water/fertility symbolism |
+| **Red ochre use** | Blood, potency, life force |
+
+---
+
+## Major Rock Art Sites
+
+### Nswatugi Cave
+
+<img src="/images/rock-art/nswatugi-cave.jpg" alt="Nswatugi Cave rock art" />
+
+The most visited and arguably most spectacular rock art site in Matobo.
+
+**Highlights:**
+- Life-sized giraffe paintings
+- Multiple kudu in various poses
+- Human figures with bows
+- Exceptional preservation
+- Dramatic cave setting
+
+**Visiting:**
+| | |
+|---|---|
+| **Location** | Central Matobo, near Maleme |
+| **Access** | Short walk from road |
+| **Difficulty** | Easy |
+| **Time** | 30-45 minutes |
+| **Guide** | Recommended |
+
+### Pomongwe Cave
+
+One of the most archaeologically significant sites in southern Africa.
+
+**Significance:**
+- 40,000+ years of human occupation
+- Multiple layers of paintings
+- Important archaeological excavations
+- Stone Age tool deposits
+- Evidence of climate adaptation
+
+**Features:**
+- Multiple painting phases visible
+- Large shelter with good lighting
+- Interpretive signage
+- Easy access
+
+### Bambata Cave
+
+Gave its name to the "Bambata Culture" - a Middle Stone Age industry.
+
+**Why it matters:**
+- Type site for archaeological culture
+- Rock art from multiple periods
+- Important research history
+- Combined natural and cultural heritage
+
+### Silozwane Cave
+
+Home to remarkable paintings including rare depictions of wildebeest.
+
+**Features:**
+- Wildebeest images (rare in Zimbabwe)
+- Multiple animal species
+- Good preservation
+- Atmospheric location
+
+### Inanke Cave
+
+Features both rock art and Iron Age remains.
+
+**Note:** Access may be restricted - check with park authorities.
+
+### White Rhino Shelter
+
+Features paintings of the now locally-extinct white rhinoceros.
+
+**Access:** Requires NMMZ permission and guide.
+
+---
+
+## Understanding the Art
+
+### Dating the Paintings
+
+| Method | Timeframe |
+|--------|-----------|
+| **Relative dating** | Superimposition (newer over older) |
+| **Style analysis** | Changes in technique over time |
+| **Archaeological context** | Associated deposits |
+| **AMS radiocarbon** | Direct dating (limited) |
+
+Most paintings are **2,000-5,000 years old**, though some may be 13,000+ years old and others as recent as 200 years ago.
+
+### The Trance Hypothesis
+
+The dominant interpretation of San rock art:
+
+1. **Shamanic healers** entered trance through dancing
+2. **Visions** experienced during trance were painted
+3. **Power animals** (especially eland) featured prominently
+4. **Transformation** (human to animal) depicted
+5. **Entoptic phenomena** (geometric patterns) recorded
+
+This interpretation comes from:
+- Ethnographic records of San peoples
+- Comparison with /Xam San oral traditions
+- Analysis of painting content
+- Neuropsychological research
+
+### Reading a Panel
+
+When viewing rock art, look for:
+
+1. **Layers** - Older paintings underneath newer
+2. **Groupings** - Related figures together
+3. **Action** - What's happening in the scene
+4. **Unusual features** - Lines from heads, bent postures
+5. **Context** - Why this location?
+
+---
+
+## Visiting the Rock Art
+
+### General Information
+
+| | |
+|---|---|
+| **Entry to Park** | $15 USD (international) |
+| **Rock Art Sites** | Included in park fee |
+| **Special Permits** | Required for some sites |
+| **Guides** | Highly recommended |
+| **Best Time** | Dry season, morning light |
+
+### Guided Tours
+
+**Why use a guide:**
+- Know exact locations
+- Explain cultural context
+- Access to restricted sites
+- Support local community
+- Ensure site protection
+
+**Where to find guides:**
+- Park headquarters
+- Maleme Rest Camp
+- Tour operators in Bulawayo
+- Lodge staff
+
+### Recommended Route
+
+**Half Day:**
+1. Nswatugi Cave (main attraction)
+2. Pomongwe Cave
+3. Return via scenic route
+
+**Full Day:**
+1. Morning: Nswatugi, Pomongwe
+2. Midday: Bambata
+3. Afternoon: World's View + additional sites
+
+**Multi-Day:**
+- Day 1: Main sites (Nswatugi, Pomongwe, Bambata)
+- Day 2: Remote sites with guide
+- Day 3: Wildlife + remaining sites
+
+---
+
+## Conservation
+
+### Threats to the Paintings
+
+| Threat | Cause | Impact |
+|--------|-------|--------|
+| **Water damage** | Rain seepage | Paint dissolution |
+| **Vandalism** | Graffiti, touching | Physical damage |
+| **Dust** | Visitors, wind | Accumulation on surfaces |
+| **Wasps** | Nest building | Paint covered/damaged |
+| **Lichen** | Growth on surfaces | Paint obscured |
+
+### Protection Measures
+
+- National Parks management
+- NMMZ monitoring
+- Visitor restrictions at sensitive sites
+- Walkways to prevent erosion
+- Educational programs
+
+### How You Can Help
+
+**DO:**
+- Keep distance from paintings
+- Stay on paths
+- Report damage
+- Use guides
+- Pay entry fees
+
+**DON'T:**
+- Touch the art (oils damage paint)
+- Use flash photography
+- Splash water on paintings
+- Remove anything
+- Mark the rocks
+
+<Warning>
+Even light touching causes damage. The oils from human skin chemically react with ancient pigments. Please keep hands off all rock surfaces.
+</Warning>
+
+---
+
+## Practical Tips
+
+### What to Bring
+
+- **Binoculars** - For viewing distant paintings
+- **Camera with zoom** - Telephoto for details
+- **Water** - Sites can be far from facilities
+- **Sun protection** - Little shade between sites
+- **Comfortable shoes** - Uneven terrain
+- **Notebook** - Record what you see
+
+### Photography
+
+| Tip | Reason |
+|-----|--------|
+| **No flash** | Damages pigments over time |
+| **Morning light** | Best angle for most caves |
+| **Polarizing filter** | Reduces rock glare |
+| **Tripod** | Low light in caves |
+| **Wide + telephoto** | Context and details |
+
+### Best Conditions
+
+- **Time of day:** Early morning (8-10 AM)
+- **Season:** Dry season (May-October)
+- **Weather:** Overcast can be good (soft light)
+- **Day of week:** Weekdays for fewer visitors
+
+---
+
+## Connecting to Wildlife
+
+Part of the magic of Matobo is seeing animals depicted in rock art alongside their living descendants:
+
+| Animal | Painting Sites | Living in Park? |
+|--------|----------------|-----------------|
+| Kudu | Many | Yes, common |
+| Giraffe | Nswatugi | No (extirpated) |
+| Eland | Several | Yes, rare |
+| Leopard | A few | Yes, elusive |
+| Baboon | Many | Yes, common |
+| White rhino | White Rhino Shelter | Yes (reintroduced) |
+
+Seeing a kudu silhouetted on a rock, then viewing 2,000-year-old paintings of kudu, creates a powerful connection to the San artists who lived here.
+
+---
+
+## Beyond Matobo
+
+If Matobo inspires your interest in rock art, consider:
+
+| Site | Location | Distance | Highlights |
+|------|----------|----------|------------|
+| Domboshava | Near Harare | 400 km | Accessible, good art |
+| Chikupo | Mashonaland Central | 450 km | Exceptional formlings |
+| Tsodilo Hills | Botswana | 700 km | "Louvre of the Desert" |
+
+<Card title="Living Art" icon="palette">
+Rock art sites are not museums - they're places where ancestors communicated with spirits, where rain was called, and where the power of the hunt was invoked. When you stand in Nswatugi Cave, you're in a space that was sacred for thousands of years.
+</Card>

--- a/rock-art/nswatugi-cave.mdx
+++ b/rock-art/nswatugi-cave.mdx
@@ -1,0 +1,274 @@
+---
+title: "Nswatugi Cave"
+description: "Visit Nswatugi Cave in Matobo Hills - Zimbabwe's most spectacular rock art gallery featuring life-sized giraffe paintings"
+---
+
+# Nswatugi Cave
+
+<img src="/images/rock-art/nswatugi-cave-main.jpg" alt="Nswatugi Cave rock art" />
+
+**Nswatugi Cave** is the most visited and arguably most spectacular rock art site in Zimbabwe's Matobo Hills. The cave features exceptional paintings including life-sized giraffes, elegant kudu, and human figures - all remarkably preserved in a dramatic granite setting.
+
+---
+
+## Quick Facts
+
+| | |
+|---|---|
+| **Location** | Matobo National Park, near Maleme |
+| **Access** | Short walk from road |
+| **Difficulty** | Easy |
+| **Time Needed** | 30-60 minutes |
+| **Entry** | Included in park fee ($15 USD) |
+| **Guides** | Recommended, available |
+
+---
+
+## What You'll See
+
+### The Giraffes
+
+Nswatugi's most famous paintings are the **life-sized giraffe images**:
+- Nearly actual size (over 2 meters tall)
+- Multiple giraffes depicted
+- Remarkable anatomical accuracy
+- Red/brown ochre pigments
+- Exceptional preservation
+
+### Kudu Paintings
+
+Multiple kudu in various poses:
+- Elegant spiral horns accurately shown
+- Different positions (standing, running)
+- Fine line work
+- Male and female depicted
+
+### Human Figures
+
+- Hunters with bows
+- Figures in various poses
+- Running/dancing scenes
+- Connection to animals
+
+### Other Animals
+
+- Various antelope species
+- Possible elephant outlines
+- Smaller mammals
+- Birds
+
+---
+
+## The Cave Setting
+
+Nswatugi is a large granite overhang rather than a true cave:
+
+**Characteristics:**
+- Wide, sheltered overhang
+- Natural amphitheater shape
+- Protection from rain and sun
+- Good natural lighting
+- Cool shade on hot days
+
+**Why This Location:**
+The San artists chose this site because:
+- Shelter from elements
+- Smooth painting surface
+- Strategic location
+- Spiritual significance
+- Good visibility
+
+---
+
+## Visiting Nswatugi
+
+### Getting There
+
+**From Maleme Rest Camp:**
+1. Exit camp toward main park road
+2. Follow signs to Nswatugi
+3. Park at designated area
+4. Short walk to cave entrance
+
+**Distance:** Approximately 5 km from Maleme Rest Camp
+
+### At the Site
+
+- Clear path to cave
+- Viewing area below paintings
+- Informative signage
+- Space for groups
+
+### Best Time
+
+| Time | Conditions |
+|------|------------|
+| **Early morning** | Cool, good light, fewer visitors |
+| **Mid-morning** | Optimal lighting in cave |
+| **Afternoon** | Can be hot, more visitors |
+| **Avoid** | Midday in summer (very hot) |
+
+---
+
+## Understanding the Art
+
+### Why Giraffes?
+
+Giraffes don't currently live in Matobo (they prefer flatter terrain), so these paintings tell us:
+- Climate/vegetation was different thousands of years ago
+- San people traveled to other areas
+- Giraffes had spiritual significance
+- The paintings are very old
+
+### Painting Techniques
+
+The Nswatugi artists demonstrated skill in:
+- **Scale** - Creating life-sized images
+- **Proportion** - Accurate animal anatomy
+- **Shading** - Some depth techniques
+- **Detail** - Distinctive giraffe patterns
+
+### Age Estimates
+
+While difficult to date precisely:
+- Likely 2,000-5,000 years old
+- Possibly older for some images
+- Multiple painting phases visible
+- Continuous use over centuries
+
+---
+
+## Photography Tips
+
+### Challenges
+
+- Low light in cave overhang
+- Reflective rock surface
+- Distance from paintings
+- Crowds at popular times
+
+### Solutions
+
+| Challenge | Solution |
+|-----------|----------|
+| Low light | Tripod, higher ISO |
+| Reflections | Polarizing filter |
+| Distance | Telephoto lens (70-200mm) |
+| Crowds | Visit early morning |
+
+### Best Shots
+
+1. **Wide view** - Cave setting with paintings
+2. **Giraffe detail** - Focus on the famous images
+3. **Comparisons** - Person for scale
+4. **Details** - Close-ups of technique
+
+<Warning>
+**No flash photography** - Flash damages ancient pigments over time. Use available light and tripod for low-light shots.
+</Warning>
+
+---
+
+## Conservation
+
+### Threats
+
+| Threat | Status |
+|--------|--------|
+| Touching | Moderate (visitors occasionally touch) |
+| Graffiti | Low (supervised site) |
+| Natural weathering | Ongoing |
+| Water damage | Managed by overhang |
+
+### Protection Measures
+
+- National Parks management
+- Visitor supervision
+- Viewing barriers at some areas
+- Regular monitoring
+
+### How You Can Help
+
+- Keep distance from paintings
+- Never touch the art
+- Report any damage
+- Stay on paths
+- Pay park fees (fund conservation)
+
+---
+
+## Combining with Other Sites
+
+Nswatugi is one of several rock art sites in Matobo:
+
+### Suggested Day
+
+**Morning:**
+- Nswatugi Cave (1 hour)
+- Pomongwe Cave (45 minutes)
+
+**Midday:**
+- Lunch at Maleme
+
+**Afternoon:**
+- Game drive or rhino tracking
+- World's View for sunset
+
+### Other Nearby Rock Art
+
+| Site | Distance | Highlights |
+|------|----------|------------|
+| Pomongwe | 8 km | Archaeological significance |
+| Bambata | 10 km | Stone Age type site |
+| Silozwane | 12 km | Wildebeest paintings |
+
+---
+
+## Practical Information
+
+### Facilities
+
+- Parking area
+- Short walking path
+- Basic signage
+- No toilets at site (use Maleme)
+- No food/drinks sold
+
+### What to Bring
+
+- Camera with telephoto
+- Binoculars
+- Water
+- Sun protection
+- Comfortable walking shoes
+
+### Accessibility
+
+- Short, mostly level walk
+- Some uneven ground
+- Not wheelchair accessible
+- Manageable for most fitness levels
+
+---
+
+## Guide Services
+
+Local guides enhance the experience:
+
+**They Provide:**
+- Exact painting locations
+- Cultural interpretation
+- Historical context
+- Optimal viewing positions
+- Other site recommendations
+
+**Where to Find:**
+- Maleme Rest Camp
+- Park headquarters
+- Bulawayo tour operators
+
+**Cost:** Approximately $10-20 USD per group
+
+<Card title="Zimbabwe's Sistine Chapel" icon="palette">
+Nswatugi has been called Zimbabwe's "Sistine Chapel" for good reason. The scale, quality, and preservation of these paintings make it one of Africa's most important rock art galleries. The life-sized giraffes alone are worth the journey to Matobo.
+</Card>

--- a/rock-art/nswatugi-cave.mdx
+++ b/rock-art/nswatugi-cave.mdx
@@ -1,6 +1,25 @@
 ---
 title: "Nswatugi Cave"
-description: "Visit Nswatugi Cave in Matobo Hills - Zimbabwe's most spectacular rock art gallery featuring life-sized giraffe paintings"
+description: >-
+  Visit Nswatugi Cave in Matobo Hills - Zimbabwe's most spectacular rock art gallery featuring life-sized giraffe paintings
+'og:image': 'https://travel-info.co.zw/images/hero-light.svg'
+'og:site_name': "Zimbabwe Travel Information"
+'twitter:card': "summary_large_image"
+'twitter:site': '@zimbabwetravel'
+'twitter:creator': '@zimbabwetravel'
+robots: 'index, follow'
+author: "Zimbabwe Travel Information"
+keywords: >-
+  nswatugi cave, matobo rock art, giraffe paintings zimbabwe, san rock art, bushman cave paintings, matobo hills caves, rock art bulawayo, zimbabwe cave art
+'og:description': >-
+  Nswatugi Cave in Matobo Hills - Zimbabwe's most spectacular rock art gallery with life-sized giraffe paintings.
+'twitter:description': >-
+  Nswatugi Cave - spectacular San rock paintings including life-sized giraffes in Matobo Hills.
+canonical: 'https://travel-info.co.zw/rock-art/nswatugi-cave'
+'article:modified_time': '2025-12-30T00:00:00Z'
+'og:title': Nswatugi Cave Rock Art | Zimbabwe Travel Information
+'og:type': "article"
+'schema:type': "TouristDestination"
 ---
 
 # Nswatugi Cave

--- a/rock-art/pomongwe-cave.mdx
+++ b/rock-art/pomongwe-cave.mdx
@@ -1,6 +1,25 @@
 ---
 title: "Pomongwe Cave"
-description: "Explore Pomongwe Cave - one of the most archaeologically important sites in southern Africa with 40,000 years of human occupation"
+description: >-
+  Explore Pomongwe Cave - one of the most archaeologically important sites in southern Africa with 40,000 years of human occupation
+'og:image': 'https://travel-info.co.zw/images/hero-light.svg'
+'og:site_name': "Zimbabwe Travel Information"
+'twitter:card': "summary_large_image"
+'twitter:site': '@zimbabwetravel'
+'twitter:creator': '@zimbabwetravel'
+robots: 'index, follow'
+author: "Zimbabwe Travel Information"
+keywords: >-
+  pomongwe cave, matobo archaeology, stone age zimbabwe, prehistoric zimbabwe, 40000 years human occupation, matobo hills caves, archaeological sites zimbabwe
+'og:description': >-
+  Pomongwe Cave - one of southern Africa's most important archaeological sites with 40,000 years of human occupation.
+'twitter:description': >-
+  Pomongwe Cave - 40,000 years of human history in Matobo Hills, one of Africa's key archaeological sites.
+canonical: 'https://travel-info.co.zw/rock-art/pomongwe-cave'
+'article:modified_time': '2025-12-30T00:00:00Z'
+'og:title': Pomongwe Cave Archaeological Site | Zimbabwe Travel Information
+'og:type': "article"
+'schema:type': "TouristDestination"
 ---
 
 # Pomongwe Cave

--- a/rock-art/pomongwe-cave.mdx
+++ b/rock-art/pomongwe-cave.mdx
@@ -1,0 +1,273 @@
+---
+title: "Pomongwe Cave"
+description: "Explore Pomongwe Cave - one of the most archaeologically important sites in southern Africa with 40,000 years of human occupation"
+---
+
+# Pomongwe Cave
+
+<img src="/images/rock-art/pomongwe-cave.jpg" alt="Pomongwe Cave rock art site" />
+
+**Pomongwe Cave** is one of the most archaeologically significant sites in southern Africa, with evidence of human occupation spanning over **40,000 years**. Located in the Matobo Hills, this large rock shelter contains both rock paintings and deep archaeological deposits that have revolutionized our understanding of Stone Age peoples.
+
+---
+
+## Quick Facts
+
+| | |
+|---|---|
+| **Location** | Matobo National Park |
+| **Human Occupation** | 40,000+ years |
+| **Type** | Rock shelter/cave |
+| **Significance** | Archaeological + rock art |
+| **Access** | Easy walk from road |
+| **Entry** | Included in park fee |
+
+---
+
+## Archaeological Importance
+
+### 40,000 Years of History
+
+Pomongwe's archaeological deposits reveal:
+- **Late Stone Age** layers
+- **Middle Stone Age** occupation
+- Continuous habitation over millennia
+- Climate change adaptations
+- Technological evolution
+
+### What Excavations Found
+
+| Period | Discoveries |
+|--------|-------------|
+| **Recent (1,000-2,000 years)** | San occupation, paintings |
+| **Late Stone Age** | Microlithic tools, bone tools |
+| **Middle Stone Age** | Larger stone implements |
+| **Earlier** | Archaic human presence |
+
+### Research History
+
+- First excavated 1920s-1930s
+- Continued research through decades
+- Benchmark site for southern African archaeology
+- Published in major academic journals
+- Referenced in textbooks worldwide
+
+---
+
+## The Rock Art
+
+### Paintings Present
+
+Pomongwe contains multiple painted panels:
+- Animal depictions
+- Human figures
+- Hunting scenes
+- Faded but visible images
+
+### Art Periods
+
+The paintings represent multiple phases:
+- Older, faded images
+- Newer, more visible paintings
+- Superimposition (newer over older)
+- Different styles and techniques
+
+### Compared to Nswatugi
+
+| Factor | Pomongwe | Nswatugi |
+|--------|----------|----------|
+| **Art quality** | Good | Exceptional |
+| **Archaeological value** | Exceptional | Lower |
+| **Preservation** | Moderate | Excellent |
+| **Visitor numbers** | Fewer | More |
+| **Overall importance** | Scientific | Artistic |
+
+---
+
+## The Cave Environment
+
+### Physical Description
+
+- Large granite overhang
+- Deep shelter from elements
+- Multiple levels of floor deposits
+- Natural lighting
+- Cool interior
+
+### Why People Lived Here
+
+**Advantages of the site:**
+- Weather protection
+- Nearby water sources
+- Game-rich surroundings
+- Defensive position
+- Tool-making materials nearby
+
+---
+
+## Visiting Pomongwe
+
+### Getting There
+
+**From Maleme Rest Camp:**
+- Follow park roads toward Pomongwe
+- Well-signposted
+- Approximately 20 minutes drive
+- Short walk from parking
+
+### What to Expect
+
+- Less dramatic than Nswatugi
+- More archaeological focus
+- Interpretive signage
+- Quieter, fewer visitors
+- Deeper historical connection
+
+### Best Combined With
+
+- Nswatugi Cave (art focus)
+- Bambata Cave (nearby)
+- General Matobo exploration
+- Wildlife viewing
+
+---
+
+## Understanding Stone Age Life
+
+### Daily Life at Pomongwe
+
+Archaeological evidence reveals:
+- **Hunting** - Bones of various game animals
+- **Gathering** - Plant remains in deposits
+- **Tool-making** - Stone flakes and cores
+- **Fire use** - Ash layers throughout
+- **Bedding** - Prepared sleeping areas
+
+### Climate Changes
+
+The deposits show:
+- Wetter periods (more forest animals)
+- Drier periods (more grassland species)
+- Adaptation to changing conditions
+- Human resilience over millennia
+
+### Technology Evolution
+
+| Period | Tools Found |
+|--------|-------------|
+| **Recent** | Small, refined blades |
+| **Middle LSA** | Backed tools, scrapers |
+| **Early LSA** | Larger implements |
+| **MSA** | Heavy-duty tools |
+
+---
+
+## Photography
+
+### Challenges
+
+- Lower light than Nswatugi
+- Less dramatic paintings
+- Archaeological rather than artistic subject
+- Cave depth
+
+### Approach
+
+- Focus on atmosphere and setting
+- Document the shelter's scale
+- Capture archaeological context
+- Wide-angle for overall views
+- Detail shots of deposits
+
+---
+
+## Educational Value
+
+### For Students
+
+Pomongwe offers lessons in:
+- Archaeological methods
+- Human evolution
+- Climate adaptation
+- Stone Age technology
+- Long-term human settlement
+
+### For General Visitors
+
+Learn about:
+- How archaeologists work
+- What ancient life was like
+- How paintings were made
+- Human story in Africa
+
+---
+
+## Practical Information
+
+### Facilities
+
+- Parking area
+- Walking path
+- Basic signage
+- No toilets (use Maleme facilities)
+
+### Time Needed
+
+- **Quick visit:** 30 minutes
+- **With guide:** 45-60 minutes
+- **With exploration:** 1+ hour
+
+### Difficulty
+
+- Easy walk
+- Some uneven ground
+- Suitable for most visitors
+
+---
+
+## Combining Sites
+
+### Half-Day Rock Art Tour
+
+**Morning:**
+1. Pomongwe Cave (archaeological focus)
+2. Short drive to Nswatugi
+3. Nswatugi Cave (artistic focus)
+
+**This combination provides:**
+- Archaeological context at Pomongwe
+- Artistic highlights at Nswatugi
+- Complete picture of San heritage
+- Efficient use of time
+
+### Full Matobo Day
+
+**Morning:**
+- Rock art sites (Pomongwe, Nswatugi)
+
+**Afternoon:**
+- Game drive
+- Rhino tracking (if available)
+- World's View sunset
+
+---
+
+## Conservation
+
+Pomongwe's archaeological deposits are irreplaceable:
+
+**Threats:**
+- Erosion
+- Uncontrolled excavation
+- Visitor impact
+- Natural weathering
+
+**Protection:**
+- National Parks management
+- No unauthorized digging
+- Controlled access
+- Regular monitoring
+
+<Card title="Time Machine" icon="clock">
+Pomongwe is as close as you can get to a time machine. Standing in this shelter, you're in a space where humans have lived, worked, and created art for 40,000 years. The paintings are just the most recent chapter of an ancient story.
+</Card>

--- a/rock-art/zombepata-cave.mdx
+++ b/rock-art/zombepata-cave.mdx
@@ -1,0 +1,299 @@
+---
+title: "Zombepata Cave"
+description: "Explore Zombepata - home to Zimbabwe's finest formlings and rare rock art subjects including porcupines, ostriches, and white zebras"
+---
+
+# Zombepata Cave
+
+<img src="/images/rock-art/zombepata-paintings.jpg" alt="Zombepata Cave rock paintings" />
+
+**Zombepata Cave** in Mashonaland Central contains some of the finest and most unusual rock art in Zimbabwe. Famous for its exceptional **formlings** and rare animal subjects - including porcupines, ostriches, and white zebras - Zombepata is a treasure for serious rock art enthusiasts.
+
+---
+
+## Quick Facts
+
+| | |
+|---|---|
+| **Location** | Guruve District, Mashonaland Central |
+| **Distance from Harare** | ~150 km |
+| **Known For** | Best formlings, rare animal subjects |
+| **Access** | Remote, requires planning |
+| **Permission** | Check with NMMZ |
+| **Difficulty** | Moderate |
+
+---
+
+## Exceptional Paintings
+
+### The Formlings
+
+Zombepata has **the finest formlings in Zimbabwe**:
+- Multiple exceptional examples
+- Clear, well-preserved forms
+- Internal patterning visible
+- Classic oval/kidney shapes
+- Associated with other imagery
+
+### Rare Animal Subjects
+
+What makes Zombepata unique is the range of unusual subjects:
+
+| Subject | Why Rare |
+|---------|----------|
+| **Porcupine** | Extremely rare in rock art - almost unique |
+| **Ostrich** | Unusual for this region |
+| **White zebras** | Rare color choice |
+| **Female kudu** | Usually males depicted |
+| **Birds (brown & white)** | Uncommon coloring technique |
+
+### Standard Subjects
+
+Also present:
+- Kudu (male and female)
+- Eland
+- Human figures
+- Hunting scenes
+
+---
+
+## Why These Rare Subjects?
+
+### The Porcupine
+
+Porcupines are almost never depicted in rock art. At Zombepata:
+- Clear porcupine identification
+- Quill-like lines depicted
+- Unique in Zimbabwe rock art
+- Possibly spiritual significance
+
+### Ostriches
+
+Ostriches don't typically feature in Zimbabwe rock art:
+- More common in drier regions (Botswana, Namibia)
+- Suggests different climate or travel
+- May indicate trade/exchange contacts
+- Spiritual associations possible
+
+### White Zebras
+
+Unusual use of white pigment for zebras:
+- Most zebras painted in black/brown
+- White pigment rarely used for mammals
+- Artistic choice or symbolic meaning?
+- Different painting tradition?
+
+---
+
+## The Formlings Explained
+
+### At Zombepata
+
+The formlings here are characterized by:
+- **Classic oval shapes** - Well-defined outlines
+- **Internal patterns** - Dots, lines, divisions
+- **Multiple examples** - Several in one shelter
+- **Good preservation** - Clear despite age
+- **Research quality** - Important for scholarship
+
+### Interpretation
+
+The Zombepata formlings support theories linking them to:
+- **Shamanic trance** - Entoptic phenomena
+- **Spiritual concepts** - Belief system elements
+- **Possibly bee-related** - Honeycomb associations
+
+---
+
+## The Cave Setting
+
+### Physical Description
+
+- Protected granite overhang
+- Smooth painting surfaces
+- Natural lighting adequate
+- Remote woodland setting
+- Peaceful atmosphere
+
+### Surrounding Area
+
+- Miombo woodland
+- Granite kopjes scattered
+- Rural communal lands
+- Traditional village life
+- Few other visitors
+
+---
+
+## Getting There
+
+### From Harare
+
+1. Drive north toward Mvurwi/Guruve
+2. Continue into Guruve District
+3. Seek local directions for final approach
+4. Some rough road sections
+
+**Distance:** ~150 km
+**Time:** 3-4 hours depending on conditions
+
+### Access Considerations
+
+| Factor | Details |
+|--------|---------|
+| **Vehicle** | High clearance recommended |
+| **Roads** | Variable, check conditions |
+| **Guide** | Essential for navigation |
+| **Permission** | Contact NMMZ |
+| **Season** | Dry season (May-Oct) best |
+
+---
+
+## Planning Your Visit
+
+### Preparation
+
+1. Contact NMMZ for access information
+2. Arrange local guide in advance
+3. Check road conditions
+4. Plan for full day trip
+5. Fuel up in Harare or Bindura
+
+### What to Bring
+
+- Full fuel tank
+- Food and water
+- Sun protection
+- Camera equipment
+- Walking shoes
+- First aid basics
+
+### Best Time
+
+| Season | Conditions |
+|--------|------------|
+| **May-Aug** | Ideal - dry, cool, easy access |
+| **Sep-Oct** | Good - dry but hot |
+| **Nov-Apr** | Avoid - wet, access difficult |
+
+---
+
+## Photography
+
+### Opportunities
+
+Zombepata offers:
+- Unique porcupine image (possibly only one in Zimbabwe)
+- Multiple formlings for documentation
+- Rare ostrich paintings
+- White zebra for comparison shots
+- Remote setting atmosphere
+
+### Technical Tips
+
+| Challenge | Solution |
+|-----------|----------|
+| Low cave light | Tripod, high ISO |
+| Distance from art | Telephoto 70-200mm+ |
+| Rock reflections | Polarizing filter |
+| Detail capture | Macro lens helpful |
+
+### Documentation
+
+As a rarely visited site, thorough photography is valuable:
+- Wide establishing shots
+- Detail images of each subject
+- Scale references
+- GPS documentation
+- Notes on condition
+
+---
+
+## Academic Significance
+
+### Research Value
+
+Zombepata is important for:
+- **Formling studies** - Key comparison site
+- **Subject diversity** - Rare animal documentation
+- **Regional patterns** - Understanding distribution
+- **Artistic techniques** - Pigment and style analysis
+
+### Publications
+
+Zombepata features in:
+- Rock art surveys of Zimbabwe
+- Formling distribution studies
+- San art interpretation
+- Archaeological journals
+
+### Research Access
+
+Contact:
+- National Museums and Monuments of Zimbabwe
+- University of Zimbabwe Archaeology Department
+- Rock Art Research Institute (South Africa)
+
+---
+
+## Combining with Other Sites
+
+### Two-Day Expedition
+
+**Day 1:**
+- Harare to Guruve area
+- Zombepata exploration
+- Overnight locally or camp
+
+**Day 2:**
+- Chikupo Cave (nearby)
+- Return to Harare
+
+### Regional Context
+
+| Site | Distance | Highlights |
+|------|----------|------------|
+| Chikupo | 30 km | Formlings, trance art |
+| Domboshava | 120 km | Accessible rock art |
+| Matobo | 450 km | Major rock art area |
+
+---
+
+## Conservation
+
+### Site Condition
+
+- Remote location offers protection
+- Natural weathering ongoing
+- Some paintings fading
+- Overall good preservation
+
+### Protection
+
+- National monument status
+- NMMZ oversight
+- Limited visitor impact
+- Community awareness
+
+### How to Help
+
+- Report condition to NMMZ
+- Document responsibly
+- Never touch paintings
+- Respect site sanctity
+
+---
+
+## The Zombepata Experience
+
+What visitors say:
+
+*"The porcupine alone is worth the journey - I've seen hundreds of rock art sites and never seen anything like it."*
+
+*"The formlings here are clearer than anywhere else. If you want to understand these mysterious shapes, you have to see Zombepata."*
+
+*"It's not easy to get here, but that's part of what makes it special. This is real discovery."*
+
+<Card title="Artistic Anomaly" icon="star">
+Zombepata challenges our understanding of San rock art. Why paint a porcupine? Why white zebras? Why are the finest formlings here rather than in Matobo? These questions make Zombepata not just beautiful but intellectually fascinating.
+</Card>

--- a/rock-art/zombepata-cave.mdx
+++ b/rock-art/zombepata-cave.mdx
@@ -1,6 +1,25 @@
 ---
 title: "Zombepata Cave"
-description: "Explore Zombepata - home to Zimbabwe's finest formlings and rare rock art subjects including porcupines, ostriches, and white zebras"
+description: >-
+  Explore Zombepata - home to Zimbabwe's finest formlings and rare rock art subjects including porcupines, ostriches, and white zebras
+'og:image': 'https://travel-info.co.zw/images/hero-light.svg'
+'og:site_name': "Zimbabwe Travel Information"
+'twitter:card': "summary_large_image"
+'twitter:site': '@zimbabwetravel'
+'twitter:creator': '@zimbabwetravel'
+robots: 'index, follow'
+author: "Zimbabwe Travel Information"
+keywords: >-
+  zombepata cave, formlings rock art, porcupine rock art, rare san paintings, guruve caves, mashonaland rock art, unusual rock art africa
+'og:description': >-
+  Zombepata Cave - Zimbabwe's finest formlings and rare rock art subjects including porcupines and white zebras.
+'twitter:description': >-
+  Zombepata Cave - rare formlings and unique animal subjects including porcupines in Mashonaland.
+canonical: 'https://travel-info.co.zw/rock-art/zombepata-cave'
+'article:modified_time': '2025-12-30T00:00:00Z'
+'og:title': Zombepata Cave Rock Art | Zimbabwe Travel Information
+'og:type': "article"
+'schema:type': "TouristDestination"
 ---
 
 # Zombepata Cave

--- a/scenic/bridal-veil-falls.mdx
+++ b/scenic/bridal-veil-falls.mdx
@@ -1,6 +1,25 @@
 ---
 title: "Bridal Veil Falls"
-description: "Visit Bridal Veil Falls near Chimanimani - a delicate cascade perfect for picnics and swimming in Zimbabwe's Eastern Highlands"
+description: >-
+  Visit Bridal Veil Falls near Chimanimani - a delicate cascade perfect for picnics and swimming in Zimbabwe's Eastern Highlands
+'og:image': 'https://travel-info.co.zw/images/hero-light.svg'
+'og:site_name': "Zimbabwe Travel Information"
+'twitter:card': "summary_large_image"
+'twitter:site': '@zimbabwetravel'
+'twitter:creator': '@zimbabwetravel'
+robots: 'index, follow'
+author: "Zimbabwe Travel Information"
+keywords: >-
+  bridal veil falls, chimanimani waterfall, swimming waterfall zimbabwe, picnic spot zimbabwe, eastern highlands falls
+'og:description': >-
+  Bridal Veil Falls near Chimanimani - a delicate cascade perfect for picnics and swimming in the Eastern Highlands.
+'twitter:description': >-
+  Bridal Veil Falls - beautiful cascade near Chimanimani, perfect for picnics and swimming.
+canonical: 'https://travel-info.co.zw/scenic/bridal-veil-falls'
+'article:modified_time': '2025-12-30T00:00:00Z'
+'og:title': Bridal Veil Falls Chimanimani | Zimbabwe Travel Information
+'og:type': "article"
+'schema:type': "TouristDestination"
 ---
 
 # Bridal Veil Falls

--- a/scenic/bridal-veil-falls.mdx
+++ b/scenic/bridal-veil-falls.mdx
@@ -1,0 +1,156 @@
+---
+title: "Bridal Veil Falls"
+description: "Visit Bridal Veil Falls near Chimanimani - a delicate cascade perfect for picnics and swimming in Zimbabwe's Eastern Highlands"
+---
+
+# Bridal Veil Falls
+
+<img src="/images/scenic/bridal-veil-falls.jpg" alt="Bridal Veil Falls Chimanimani" />
+
+**Bridal Veil Falls** is a graceful waterfall near Chimanimani village, named for its delicate, veil-like appearance. While not the tallest, it's one of the most accessible and picturesque waterfalls in the Eastern Highlands, perfect for a relaxed visit.
+
+---
+
+## Quick Facts
+
+| | |
+|---|---|
+| **Height** | ~50 meters |
+| **Location** | Near Chimanimani village |
+| **Type** | Horsetail/veil cascade |
+| **Access** | Short easy walk |
+| **Swimming** | Pool at base |
+| **Best For** | Picnics, relaxation |
+
+---
+
+## The Falls
+
+### Character
+
+Unlike thundering Victoria Falls, Bridal Veil is:
+- **Delicate** - Wispy, veil-like water flow
+- **Scenic** - Framed by lush vegetation
+- **Peaceful** - Relaxed atmosphere
+- **Accessible** - Easy to reach
+- **Swimmable** - Pool at the base
+
+### Best Flow
+
+| Season | Water Level |
+|--------|-------------|
+| **Dec-Apr** | Best flow, most impressive |
+| **May-Aug** | Moderate, still pretty |
+| **Sep-Nov** | Lower, but year-round flow |
+
+---
+
+## Getting There
+
+### From Chimanimani Village
+
+1. Head out of village on Mutare road
+2. Watch for signpost on left
+3. Turn onto dirt track
+4. Short drive to parking
+5. Walk ~10 minutes to falls
+
+**Distance:** 3 km from village
+**Road:** Dirt, but manageable
+
+### From Mutare
+
+- **Distance:** ~150 km
+- **Time:** 2-2.5 hours
+- **Route:** Via Wengezi Junction
+
+---
+
+## At the Falls
+
+### What to Do
+
+- **Swim** - Pool at base (check depth)
+- **Picnic** - Lovely spot for lunch
+- **Photograph** - Scenic composition
+- **Relax** - Natural atmosphere
+- **Bird watch** - Forest species
+
+### Facilities
+
+- Parking area nearby
+- No formal facilities
+- Bring your own supplies
+- Natural shade
+
+---
+
+## Best Time to Visit
+
+### When to Go
+
+| Factor | Recommendation |
+|--------|----------------|
+| **Water flow** | January-March best |
+| **Weather** | May-September coolest |
+| **Swimming** | November-April warmest |
+| **Crowds** | Weekdays quieter |
+
+### Time Needed
+
+- **Quick visit:** 30 minutes
+- **With swimming:** 1-2 hours
+- **With picnic:** Half day
+
+---
+
+## Photography
+
+### Tips
+
+- Morning or late afternoon light
+- Use slow shutter for silky water
+- Include vegetation for framing
+- Portrait orientation works well
+- Person adds scale
+
+---
+
+## What to Bring
+
+- Swimsuit and towel
+- Picnic supplies
+- Camera
+- Sun protection
+- Shoes that can get wet
+
+---
+
+## Nearby Attractions
+
+| Attraction | Distance | Highlights |
+|------------|----------|------------|
+| Chimanimani Mountains | 5 km | Hiking, wilderness |
+| Chimanimani village | 3 km | Crafts, supplies |
+| Vimba Falls | 10 km | Another waterfall |
+| Tarka Forest | 15 km | Walking, birds |
+
+---
+
+## Combining Visits
+
+### Chimanimani Day
+
+**Morning:** Bridal Veil Falls (swim/picnic)
+**Afternoon:** Chimanimani village crafts
+**Evening:** Local dinner
+
+### Chimanimani Weekend
+
+**Day 1:** Arrive, Bridal Veil Falls
+**Day 2:** Mountain hiking
+**Day 3:** Explore area, return
+
+<Card title="Simple Beauty" icon="heart">
+Not every waterfall needs to be massive to be memorable. Bridal Veil Falls offers a gentle, accessible natural experience - perfect for families, picnics, and simply enjoying the Eastern Highlands atmosphere.
+</Card>

--- a/scenic/chilojo-cliffs.mdx
+++ b/scenic/chilojo-cliffs.mdx
@@ -1,0 +1,161 @@
+---
+title: "Chilojo Cliffs"
+description: "Discover the Chilojo Cliffs in Gonarezhou - dramatic red sandstone formations rising 180 meters above the Runde River"
+---
+
+# Chilojo Cliffs
+
+<img src="/images/scenic/chilojo-cliffs.jpg" alt="Chilojo Cliffs Gonarezhou" />
+
+The **Chilojo Cliffs** are Gonarezhou National Park's most dramatic landmark - towering walls of red sandstone rising 180 meters above the Runde River. These spectacular formations glow orange-red in the afternoon sun, creating one of southern Africa's most unforgettable vistas.
+
+---
+
+## Quick Facts
+
+| | |
+|---|---|
+| **Height** | 180 meters |
+| **Type** | Red sandstone cliffs |
+| **Location** | Gonarezhou National Park |
+| **Best Light** | Late afternoon |
+| **Access** | Game drive routes |
+| **Wildlife** | Often elephants below |
+
+---
+
+## The Cliffs
+
+### Formation
+
+- **Sandstone** deposited millions of years ago
+- **Iron oxide** gives red color
+- **Erosion** carved dramatic shapes
+- **River action** shaped base
+
+### Character
+
+| Feature | Description |
+|---------|-------------|
+| **Color** | Deep red/orange sandstone |
+| **Height** | 180 meters vertical faces |
+| **Length** | Extends along river |
+| **Light** | Changes dramatically through day |
+
+---
+
+## Why "Chilojo"?
+
+The name comes from the Shangaan language. The cliffs are a landmark feature visible from great distances, guiding travelers through this remote wilderness.
+
+---
+
+## Best Viewing
+
+### Viewpoints
+
+| Location | Experience |
+|----------|------------|
+| **Opposite bank** | Classic full view |
+| **Chipinda Pools** | Base of cliffs |
+| **Various game drives** | Different angles |
+
+### Time of Day
+
+| Time | Light |
+|------|-------|
+| **Morning** | Softer, shadowed |
+| **Midday** | Harsh, washed out |
+| **Late afternoon** | Golden, dramatic |
+| **Sunset** | Red glow - spectacular |
+
+### Best Months
+
+- **May-October** dry season
+- Clearer skies
+- River levels lower
+- Wildlife concentrated
+
+---
+
+## Wildlife at Chilojo
+
+### What You Might See
+
+The Runde River below the cliffs attracts:
+- **Elephants** - Often seen below cliffs
+- **Hippos** - In river pools
+- **Crocodiles** - Along riverbanks
+- **Buffalo** - Coming to drink
+- **Antelopes** - Various species
+
+---
+
+## Getting There
+
+### Access to Gonarezhou
+
+| Route | From | Distance |
+|-------|------|----------|
+| **Main** | Chiredzi | 50 km |
+| **Northern** | Masvingo | 150 km |
+
+### Within the Park
+
+- Game drive roads to viewpoints
+- Self-drive or guided
+- 4x4 recommended
+- Allow full day for exploring
+
+---
+
+## Photography
+
+### Tips
+
+- **Late afternoon** essential for color
+- **Telephoto** for cliff details
+- **Wide angle** for full panorama
+- **Include river** for scale
+- **Elephants + cliffs** = classic shot
+
+### Classic Shots
+
+1. Cliffs glowing at sunset
+2. Elephants crossing river below
+3. Panorama with Runde River
+4. Detail of rock patterns
+
+---
+
+## Practical Information
+
+### Facilities
+
+- No facilities at viewpoints
+- Basic camps in park
+- Bring all supplies
+- Self-sufficient required
+
+### What to Bring
+
+- Camera with telephoto
+- Binoculars
+- Water
+- Sun protection
+- 4x4 vehicle
+
+---
+
+## Nearby Attractions
+
+| Attraction | Description |
+|------------|-------------|
+| Chipinda Pools | Swimming, camping |
+| Runde River | Wildlife viewing |
+| Gonarezhou wilderness | Remote game drives |
+| Save Valley | Adjacent conservancy |
+
+<Card title="Africa's Grand Canyon" icon="mountain">
+The Chilojo Cliffs have been called "Africa's Grand Canyon" - perhaps an exaggeration, but the scale and color of these formations create genuine drama. With elephants wandering below and the sun turning the sandstone to fire, it's quintessential African wilderness scenery.
+</Card>

--- a/scenic/chilojo-cliffs.mdx
+++ b/scenic/chilojo-cliffs.mdx
@@ -1,6 +1,25 @@
 ---
 title: "Chilojo Cliffs"
-description: "Discover the Chilojo Cliffs in Gonarezhou - dramatic red sandstone formations rising 180 meters above the Runde River"
+description: >-
+  Discover the Chilojo Cliffs in Gonarezhou - dramatic red sandstone formations rising 180 meters above the Runde River
+'og:image': 'https://travel-info.co.zw/images/hero-light.svg'
+'og:site_name': "Zimbabwe Travel Information"
+'twitter:card': "summary_large_image"
+'twitter:site': '@zimbabwetravel'
+'twitter:creator': '@zimbabwetravel'
+robots: 'index, follow'
+author: "Zimbabwe Travel Information"
+keywords: >-
+  chilojo cliffs, gonarezhou national park, red sandstone cliffs, runde river, elephants gonarezhou, zimbabwe wilderness
+'og:description': >-
+  Chilojo Cliffs in Gonarezhou - dramatic red sandstone formations rising 180 meters above the Runde River.
+'twitter:description': >-
+  Chilojo Cliffs - dramatic red sandstone formations in Gonarezhou National Park, Zimbabwe.
+canonical: 'https://travel-info.co.zw/scenic/chilojo-cliffs'
+'article:modified_time': '2025-12-30T00:00:00Z'
+'og:title': Chilojo Cliffs Gonarezhou | Zimbabwe Travel Information
+'og:type': "article"
+'schema:type': "TouristDestination"
 ---
 
 # Chilojo Cliffs

--- a/scenic/index.mdx
+++ b/scenic/index.mdx
@@ -1,6 +1,25 @@
 ---
 title: "Scenic Wonders"
-description: "Discover Zimbabwe's most spectacular viewpoints, waterfalls, and natural landscapes - from Victoria Falls to hidden mountain vistas"
+description: >-
+  Discover Zimbabwe's most spectacular viewpoints, waterfalls, and natural landscapes - from Victoria Falls to hidden mountain vistas
+'og:image': 'https://travel-info.co.zw/images/hero-light.svg'
+'og:site_name': "Zimbabwe Travel Information"
+'twitter:card': "summary_large_image"
+'twitter:site': '@zimbabwetravel'
+'twitter:creator': '@zimbabwetravel'
+robots: 'index, follow'
+author: "Zimbabwe Travel Information"
+keywords: >-
+  zimbabwe scenery, victoria falls, mtarazi falls, eastern highlands, matobo hills views, scenic viewpoints zimbabwe, waterfalls zimbabwe
+'og:description': >-
+  Zimbabwe's most spectacular scenery - waterfalls, mountain viewpoints, and natural landscapes across the country.
+'twitter:description': >-
+  Scenic wonders of Zimbabwe - from Victoria Falls to hidden mountain viewpoints and waterfalls.
+canonical: 'https://travel-info.co.zw/scenic/index'
+'article:modified_time': '2025-12-30T00:00:00Z'
+'og:title': Scenic Wonders of Zimbabwe | Zimbabwe Travel Information
+'og:type': "article"
+'schema:type': "TouristDestination"
 ---
 
 # Scenic Wonders of Zimbabwe

--- a/scenic/index.mdx
+++ b/scenic/index.mdx
@@ -1,0 +1,386 @@
+---
+title: "Scenic Wonders"
+description: "Discover Zimbabwe's most spectacular viewpoints, waterfalls, and natural landscapes - from Victoria Falls to hidden mountain vistas"
+---
+
+# Scenic Wonders of Zimbabwe
+
+<img src="/images/scenic/zimbabwe-scenic-overview.jpg" alt="Scenic landscape in Zimbabwe" />
+
+Zimbabwe's diverse landscapes offer countless opportunities for experiencing natural beauty - from the thundering power of Victoria Falls to the serene highlands of Nyanga, the dramatic kopjes of Matobo to the wild Zambezi Valley.
+
+---
+
+## Waterfalls
+
+### Victoria Falls
+
+<img src="/images/scenic/victoria-falls-rainbow.jpg" alt="Victoria Falls with rainbow" />
+
+One of the Seven Natural Wonders of the World:
+
+| | |
+|---|---|
+| **Width** | 1,708 meters |
+| **Height** | 108 meters |
+| **Flow** | Up to 500 million liters/minute |
+| **Spray** | Visible from 50 km away |
+
+**Best Viewpoints:**
+- Devil's Cataract
+- Main Falls
+- Rainbow Falls
+- Danger Point
+- Livingstone Island (Zambia side)
+
+**When to Visit:**
+| Season | Water Level | Spray | Visibility |
+|--------|-------------|-------|------------|
+| **Feb-May** | Peak flood | Massive | Limited by spray |
+| **Jun-Aug** | High | Heavy | Good |
+| **Sep-Nov** | Low | Light | Excellent |
+| **Dec-Jan** | Rising | Moderate | Good |
+
+[Full Victoria Falls Guide →](/destinations/victoria-falls)
+
+---
+
+### Mtarazi Falls
+
+Zimbabwe's highest waterfall:
+
+| | |
+|---|---|
+| **Height** | 762 meters (combined drop) |
+| **Location** | Nyanga National Park |
+| **Type** | Multi-tier cascade |
+| **Access** | Hiking required |
+
+**Experience:**
+- Dramatic Eastern Highlands setting
+- Hiking trail to viewpoints
+- Combined with Nyanga attractions
+- Less crowded than Victoria Falls
+
+---
+
+### Pungwe Falls
+
+Another Eastern Highlands gem:
+
+| | |
+|---|---|
+| **Height** | 240 meters |
+| **Location** | Nyanga/Honde Valley |
+| **Setting** | Dense forest |
+| **Access** | Short walk |
+
+---
+
+### Bridal Veil Falls (Chimanimani)
+
+Delicate cascade in mountain setting:
+
+- Near Chimanimani village
+- Easy access
+- Picnic spot
+- Year-round flow
+
+---
+
+### Other Waterfalls
+
+| Waterfall | Location | Height | Access |
+|-----------|----------|--------|--------|
+| **Odzani Falls** | Mutare | 50m | Easy |
+| **Nyangombe Falls** | Nyanga | 25m | Easy |
+| **Various Chimanimani** | Chimanimani | Various | Hiking |
+
+---
+
+## Mountain Viewpoints
+
+### World's View (Nyanga)
+
+<img src="/images/scenic/worlds-view-nyanga.jpg" alt="World's View Nyanga" />
+
+Stunning panoramic viewpoint:
+
+| | |
+|---|---|
+| **Location** | Nyanga National Park |
+| **Altitude** | 2,100+ meters |
+| **View** | Eastern Highlands, Mozambique |
+| **Access** | Drive + short walk |
+
+**Features:**
+- 360-degree views
+- Scenic drive to reach
+- Best at sunrise/sunset
+- Clear days see to Mozambique
+
+---
+
+### World's View (Matobo)
+
+Different site, equally dramatic:
+
+| | |
+|---|---|
+| **Location** | Matobo National Park |
+| **Known For** | Cecil Rhodes' grave |
+| **View** | Endless granite kopjes |
+| **Access** | Short walk from parking |
+
+**Features:**
+- Burial site of Cecil Rhodes
+- Balancing rocks panorama
+- Sunset viewpoint
+- Historical significance
+
+---
+
+### Nyangani (Mount Inyangani)
+
+Zimbabwe's highest peak:
+
+| | |
+|---|---|
+| **Height** | 2,592 meters |
+| **Location** | Nyanga National Park |
+| **Hike** | 3-4 hours round trip |
+| **Difficulty** | Moderate-challenging |
+
+**Experience:**
+- Highest point in Zimbabwe
+- Challenging but rewarding hike
+- Alpine-like environment
+- Mist common - take care
+
+---
+
+### Chimanimani Mountains
+
+Wild mountain scenery:
+
+**Key Viewpoints:**
+- **Tessa's Pool area** - Mountain pools and views
+- **Bailey's Folly route** - Dramatic valleys
+- **Skeleton Pass** - Border panoramas
+- **Various peaks** - Multi-day hiking
+
+---
+
+### Bvumba Mountains
+
+Misty highland views:
+
+| | |
+|---|---|
+| **Location** | Near Mutare |
+| **Character** | Cool, misty, forested |
+| **Views** | Into Mozambique |
+| **Access** | Easy by car |
+
+**Viewpoints:**
+- Various lodges and gardens
+- Leopard Rock area
+- Tony's Coffee Shop viewpoint
+- Burma Valley views
+
+---
+
+## Valley & River Scenery
+
+### Zambezi Escarpment
+
+Dramatic valley views:
+
+**Viewing Points:**
+- **Kariba Dam wall** - Engineering and nature
+- **Makuti area** - Valley overlooks
+- **Chirundu road** - Descending views
+- **Mana Pools approach** - Escarpment drama
+
+### Limpopo Valley Views
+
+Southern Zimbabwe scenery:
+
+- **Gonarezhou viewpoints** - Remote wilderness
+- **Chilojo Cliffs** - Dramatic red cliffs
+- **Various overlooks** - River valley scenes
+
+---
+
+## Lake Scenery
+
+### Lake Kariba
+
+<img src="/images/scenic/lake-kariba-sunset.jpg" alt="Lake Kariba sunset" />
+
+Vast man-made lake:
+
+| | |
+|---|---|
+| **Length** | 220 km |
+| **Width** | Up to 40 km |
+| **Setting** | Drowned forest, islands |
+| **Sunsets** | Legendary |
+
+**Best Views:**
+- Kariba Heights
+- Houseboat deck
+- Matusadona shore
+- From the dam wall
+
+---
+
+### Lake Chivero
+
+Harare's scenic escape:
+
+- Game park surroundings
+- Boating views
+- Granite kopjes
+- Easy access
+
+---
+
+### Lake Mutirikwi (Kyle)
+
+Near Great Zimbabwe:
+
+- Mountain backdrop
+- Wildlife shores
+- Boating access
+- Historic lodge sites
+
+---
+
+## Granite Landscapes
+
+### Matobo Hills
+
+<img src="/images/scenic/matobo-hills-landscape.jpg" alt="Matobo Hills landscape" />
+
+Unique granite scenery:
+
+**Characteristics:**
+- Ancient granite kopjes
+- Balancing rocks everywhere
+- Castle-like formations
+- Whalebacks and domes
+
+**Key Areas:**
+- Maleme Dam area
+- World's View
+- Nswatugi area
+- Throughout park
+
+[Explore Matobo Hills →](/destinations/matobo-hills)
+
+---
+
+### Domboshava
+
+Dramatic dome near Harare:
+
+- Single massive granite dome
+- Panoramic summit views
+- Balancing rocks
+- Easy access
+
+[Explore Domboshava →](/destinations/domboshava)
+
+---
+
+## Scenic Drives
+
+### Scenic Routes
+
+| Route | Distance | Highlights |
+|-------|----------|------------|
+| **Mutare-Nyanga** | 100 km | Mountain passes, valleys |
+| **Christmas Pass** | 20 km | Near Mutare, forest drive |
+| **Burma Valley** | Various | Tea estates, views |
+| **Bvumba Road** | 30 km | Misty highlands |
+| **Zambezi Escarpment** | Various | Valley descent |
+| **Kariba Road** | Various | Lake approaches |
+
+### Road Trip: Eastern Highlands
+
+**Suggested Route:**
+1. Harare to Nyanga (scenic route)
+2. Nyanga National Park
+3. Through Troutbeck to Bvumba
+4. Chimanimani
+5. Return via Mutare
+
+---
+
+## Best Times for Scenery
+
+### By Season
+
+| Season | Conditions | Best For |
+|--------|------------|----------|
+| **May-Aug** | Clear, dry | Mountain views, photography |
+| **Sep-Oct** | Hazy, hot | Waterfalls (lower flow) |
+| **Nov-Feb** | Green, rainy | Lush landscapes, waterfalls peak |
+| **Mar-Apr** | Clearing | Good all-round |
+
+### Golden Hours
+
+| Time | Best For |
+|------|----------|
+| **Sunrise** | Mountains, lakes, dramatic skies |
+| **Mid-morning** | Waterfalls, general landscapes |
+| **Late afternoon** | Granite formations, warm light |
+| **Sunset** | Lake Kariba, Matobo, viewpoints |
+| **Blue hour** | Moody mountain scenes |
+
+---
+
+## Photography Tips
+
+### Equipment
+
+| Lens | Use |
+|------|-----|
+| **Wide-angle (16-35mm)** | Landscapes, waterfalls |
+| **Standard zoom (24-70mm)** | General scenes |
+| **Telephoto (70-200mm)** | Details, compression |
+| **Polarizer** | Reduce glare, enhance sky |
+| **ND filters** | Slow water motion |
+| **Tripod** | Low light, waterfalls |
+
+### Techniques
+
+- **Victoria Falls:** Waterproof camera gear, ND filters
+- **Mountains:** Patience for clear weather
+- **Lakes:** Golden hour priority
+- **Granite:** Side lighting for texture
+- **Forests:** Overcast for even light
+
+---
+
+## Planning Scenic Visits
+
+### Suggested Combinations
+
+**Long Weekend:**
+- Day 1: Harare to Nyanga
+- Day 2: Mtarazi Falls, World's View
+- Day 3: Return via scenic route
+
+**One Week:**
+- Days 1-3: Eastern Highlands (Nyanga, Bvumba, Chimanimani)
+- Days 4-5: Matobo Hills
+- Days 6-7: Victoria Falls
+
+**Two Weeks:**
+- Add: Lake Kariba, Gonarezhou, Mana Pools
+
+<Card title="A Country of Contrasts" icon="mountain-sun">
+From the mist-shrouded Eastern Highlands to the sun-baked Zambezi Valley, Zimbabwe packs extraordinary scenic diversity into its borders. Each region offers unique landscapes you won't find anywhere else.
+</Card>

--- a/scenic/mtarazi-falls.mdx
+++ b/scenic/mtarazi-falls.mdx
@@ -1,0 +1,165 @@
+---
+title: "Mtarazi Falls"
+description: "Hike to Mtarazi Falls - Zimbabwe's highest waterfall with a 762-meter combined drop in the stunning Eastern Highlands"
+---
+
+# Mtarazi Falls
+
+<img src="/images/scenic/mtarazi-falls.jpg" alt="Mtarazi Falls Zimbabwe" />
+
+**Mtarazi Falls** is Zimbabwe's highest waterfall, with a combined drop of **762 meters** over multiple tiers. Located in Nyanga National Park in the Eastern Highlands, the falls cascade down dramatic cliffs into the Honde Valley below.
+
+---
+
+## Quick Facts
+
+| | |
+|---|---|
+| **Height** | 762 meters (combined drop) |
+| **Location** | Nyanga National Park |
+| **Type** | Multi-tier cascade |
+| **Best Flow** | November - April |
+| **Hike** | Required to viewpoints |
+| **Entry** | Park fees apply |
+
+---
+
+## The Falls
+
+### Height Comparison
+
+| Waterfall | Height |
+|-----------|--------|
+| **Mtarazi Falls** | 762 m |
+| Victoria Falls | 108 m |
+| Pungwe Falls | 240 m |
+| Bridal Veil Falls | 50 m |
+
+### What to Expect
+
+- **Multi-tier drops** - Not a single plunge
+- **Dramatic escarpment** - Falls down cliff edge
+- **Mist and spray** - At high water
+- **Valley views** - Honde Valley below
+- **Remote setting** - Wilderness atmosphere
+
+---
+
+## Hiking to the Falls
+
+### Main Trail
+
+| | |
+|---|---|
+| **Distance** | ~6 km round trip |
+| **Time** | 3-4 hours |
+| **Difficulty** | Moderate |
+| **Terrain** | Forest, grassland, escarpment edge |
+
+### Trail Description
+
+1. **Start:** Mtarazi Falls car park
+2. **Through forest** on defined path
+3. **Emerge at escarpment** edge
+4. **Viewpoints** along cliff edge
+5. **Return:** Same route back
+
+### Viewpoints
+
+Multiple vantage points along the escarpment:
+- **Upper viewpoint** - Falls from above
+- **Main viewpoint** - Classic full view
+- **Lower viewpoint** - Alternative angle
+
+---
+
+## When to Visit
+
+### By Season
+
+| Season | Water Flow | Conditions |
+|--------|------------|------------|
+| **Nov-Apr** | Peak | Dramatic but misty |
+| **May-Jul** | Good | Clear views, good flow |
+| **Aug-Oct** | Low | Less impressive, clearest |
+
+### Best Months
+
+**For photography:** May-July (good flow + visibility)
+**For drama:** February-March (peak water)
+**For clear skies:** August-September
+
+---
+
+## Getting There
+
+### From Nyanga Village
+
+1. Enter Nyanga National Park
+2. Follow signs to Mtarazi Falls
+3. Park at designated area
+4. Begin hike on marked trail
+
+**Distance from Nyanga:** ~25 km
+**Road:** Good tar road within park
+
+### From Harare
+
+- **Distance:** ~270 km
+- **Time:** 4-5 hours
+- **Route:** Via Rusape or Mutare
+
+---
+
+## What to Bring
+
+**Essential:**
+- Good hiking boots
+- Water (2+ liters)
+- Sun protection
+- Rain jacket (mist, highland weather)
+- Camera
+
+**Recommended:**
+- Binoculars
+- Picnic lunch
+- Warm layer (highlands cool)
+
+---
+
+## Photography Tips
+
+- **Wide angle** for full falls view
+- **Telephoto** for detail shots
+- **Tripod** for slow water effects
+- **Waterproof cover** for mist
+- **Morning light** generally best
+
+---
+
+## Safety
+
+<Warning>
+Stay well back from cliff edges. The escarpment is steep and dangerous. Conditions can be slippery after rain.
+</Warning>
+
+- Stay on marked trails
+- Don't climb over barriers
+- Watch children carefully
+- Avoid in thunderstorms
+- Inform someone of plans
+
+---
+
+## Nearby Attractions
+
+| Attraction | Distance | Highlights |
+|------------|----------|------------|
+| World's View | 15 km | Panoramic viewpoint |
+| Nyanga Village | 25 km | Trout fishing, lodges |
+| Pungwe Falls | 40 km | Another waterfall |
+| Troutbeck | 30 km | Highland resort |
+
+<Card title="Zimbabwe's Highest" icon="droplet">
+While Victoria Falls is more famous, Mtarazi Falls is over seven times higher. For those who make the hike, the reward is one of Africa's most dramatic waterfalls in a pristine mountain setting.
+</Card>

--- a/scenic/mtarazi-falls.mdx
+++ b/scenic/mtarazi-falls.mdx
@@ -1,6 +1,25 @@
 ---
 title: "Mtarazi Falls"
-description: "Hike to Mtarazi Falls - Zimbabwe's highest waterfall with a 762-meter combined drop in the stunning Eastern Highlands"
+description: >-
+  Hike to Mtarazi Falls - Zimbabwe's highest waterfall with a 762-meter combined drop in the stunning Eastern Highlands
+'og:image': 'https://travel-info.co.zw/images/hero-light.svg'
+'og:site_name': "Zimbabwe Travel Information"
+'twitter:card': "summary_large_image"
+'twitter:site': '@zimbabwetravel'
+'twitter:creator': '@zimbabwetravel'
+robots: 'index, follow'
+author: "Zimbabwe Travel Information"
+keywords: >-
+  mtarazi falls, highest waterfall zimbabwe, nyanga waterfalls, eastern highlands waterfall, hiking nyanga, 762 meter waterfall africa
+'og:description': >-
+  Mtarazi Falls - Zimbabwe's highest waterfall at 762 meters in Nyanga National Park, Eastern Highlands.
+'twitter:description': >-
+  Mtarazi Falls - Zimbabwe's highest waterfall with 762-meter drop in the stunning Eastern Highlands.
+canonical: 'https://travel-info.co.zw/scenic/mtarazi-falls'
+'article:modified_time': '2025-12-30T00:00:00Z'
+'og:title': Mtarazi Falls - Zimbabwe's Highest Waterfall | Zimbabwe Travel Information
+'og:type': "article"
+'schema:type': "TouristDestination"
 ---
 
 # Mtarazi Falls

--- a/scenic/pungwe-falls.mdx
+++ b/scenic/pungwe-falls.mdx
@@ -1,0 +1,150 @@
+---
+title: "Pungwe Falls"
+description: "Visit Pungwe Falls - a dramatic 240-meter cascade in the misty forests of Zimbabwe's Eastern Highlands"
+---
+
+# Pungwe Falls
+
+<img src="/images/scenic/pungwe-falls.jpg" alt="Pungwe Falls Zimbabwe" />
+
+**Pungwe Falls** drops 240 meters through lush montane forest in the Eastern Highlands, offering a more accessible waterfall experience than Mtarazi. The Pungwe River plunges over the escarpment edge, creating a spectacular cascade surrounded by indigenous forest.
+
+---
+
+## Quick Facts
+
+| | |
+|---|---|
+| **Height** | 240 meters |
+| **Location** | Nyanga National Park / Pungwe area |
+| **Type** | Single plunge cascade |
+| **Access** | Moderate walk |
+| **Best Flow** | November - May |
+| **Setting** | Montane forest |
+
+---
+
+## The Falls
+
+### Characteristics
+
+- **Single major drop** - More dramatic than Mtarazi's tiers
+- **Forest setting** - Surrounded by indigenous trees
+- **Mist zone** - Creates mini-rainforest
+- **River gorge** - Dramatic canyon below
+- **Year-round flow** - Though seasonal variation
+
+### Height Comparison
+
+| Waterfall | Height | Character |
+|-----------|--------|-----------|
+| Mtarazi | 762 m | Multi-tier |
+| **Pungwe** | 240 m | Single plunge |
+| Victoria Falls | 108 m | Curtain wall |
+
+---
+
+## Getting There
+
+### Location
+
+Pungwe Falls lies on the border of Nyanga National Park, near the escarpment edge.
+
+### From Nyanga Village
+
+1. Take the road toward Honde Valley
+2. Watch for Pungwe Falls signage
+3. Turn onto access road
+4. Park and walk to viewpoints
+
+**Distance:** ~30 km from Nyanga
+**Road:** Mostly tar, some gravel
+
+### From Mutare
+
+- Via Juliasdale route
+- Approximately 80 km
+- Scenic mountain drive
+
+---
+
+## Visiting the Falls
+
+### Access
+
+| Option | Distance | Difficulty |
+|--------|----------|------------|
+| Upper viewpoint | 500 m walk | Easy |
+| Lower viewpoint | 1.5 km | Moderate |
+| Gorge base | Not recommended | Dangerous |
+
+### What to Expect
+
+- **Upper viewpoint** - Look down on the falls
+- **Lower viewpoint** - See falls from side
+- **Forest walk** - Beautiful indigenous trees
+- **Bird life** - Many forest species
+
+---
+
+## Best Time to Visit
+
+### Seasonal Conditions
+
+| Season | Flow | Experience |
+|--------|------|------------|
+| **Feb-Apr** | Peak | Dramatic, often misty |
+| **May-Jul** | Good | Clear views, solid flow |
+| **Aug-Oct** | Lower | Easiest viewing |
+| **Nov-Jan** | Rising | Unpredictable |
+
+### Weather
+
+The highlands can be:
+- Misty (especially mornings)
+- Cool year-round
+- Rainy afternoons (wet season)
+- Clear mornings (dry season)
+
+---
+
+## Photography
+
+### Best Shots
+
+- Falls from upper viewpoint
+- Forest framing
+- Mist and atmosphere
+- Detail of cascading water
+
+### Tips
+
+- Morning before mist rises
+- Slow shutter for silky water
+- Wide angle for forest context
+- Rain jacket protects camera
+
+---
+
+## What to Bring
+
+- Warm jacket (highlands cool)
+- Rain gear (mist common)
+- Good walking shoes
+- Camera
+- Water and snacks
+
+---
+
+## Nearby Attractions
+
+| Attraction | Distance | Highlights |
+|------------|----------|------------|
+| Mtarazi Falls | 20 km | Zimbabwe's highest |
+| Honde Valley | Below | Tea estates, views |
+| World's View | 20 km | Panoramic vistas |
+| Nyanga Village | 30 km | Services, lodges |
+
+<Card title="Forest Gem" icon="tree">
+Pungwe Falls combines dramatic water with intimate forest atmosphere. Less visited than Mtarazi, it offers a quieter experience in one of Zimbabwe's most beautiful highland settings.
+</Card>

--- a/scenic/pungwe-falls.mdx
+++ b/scenic/pungwe-falls.mdx
@@ -1,6 +1,25 @@
 ---
 title: "Pungwe Falls"
-description: "Visit Pungwe Falls - a dramatic 240-meter cascade in the misty forests of Zimbabwe's Eastern Highlands"
+description: >-
+  Visit Pungwe Falls - a dramatic 240-meter cascade in the misty forests of Zimbabwe's Eastern Highlands
+'og:image': 'https://travel-info.co.zw/images/hero-light.svg'
+'og:site_name': "Zimbabwe Travel Information"
+'twitter:card': "summary_large_image"
+'twitter:site': '@zimbabwetravel'
+'twitter:creator': '@zimbabwetravel'
+robots: 'index, follow'
+author: "Zimbabwe Travel Information"
+keywords: >-
+  pungwe falls, nyanga waterfalls, eastern highlands waterfall, honde valley, forest waterfall zimbabwe, 240 meter waterfall
+'og:description': >-
+  Pungwe Falls - a dramatic 240-meter cascade surrounded by misty forests in Zimbabwe's Eastern Highlands.
+'twitter:description': >-
+  Pungwe Falls - 240-meter cascade in the misty forests of Zimbabwe's Eastern Highlands.
+canonical: 'https://travel-info.co.zw/scenic/pungwe-falls'
+'article:modified_time': '2025-12-30T00:00:00Z'
+'og:title': Pungwe Falls | Zimbabwe Travel Information
+'og:type': "article"
+'schema:type': "TouristDestination"
 ---
 
 # Pungwe Falls

--- a/scenic/worlds-view-matobo.mdx
+++ b/scenic/worlds-view-matobo.mdx
@@ -1,6 +1,25 @@
 ---
 title: "World's View (Matobo)"
-description: "Visit World's View in Matobo Hills - Cecil Rhodes' burial site and one of Zimbabwe's most dramatic viewpoints over endless granite kopjes"
+description: >-
+  Visit World's View in Matobo Hills - Cecil Rhodes' burial site and one of Zimbabwe's most dramatic viewpoints over endless granite kopjes
+'og:image': 'https://travel-info.co.zw/images/hero-light.svg'
+'og:site_name': "Zimbabwe Travel Information"
+'twitter:card': "summary_large_image"
+'twitter:site': '@zimbabwetravel'
+'twitter:creator': '@zimbabwetravel'
+robots: 'index, follow'
+author: "Zimbabwe Travel Information"
+keywords: >-
+  worlds view matobo, cecil rhodes grave, matobo viewpoint, matopos sunset, granite kopjes view, matobo hills zimbabwe
+'og:description': >-
+  World's View in Matobo Hills - Cecil Rhodes' burial site with dramatic views over endless granite kopjes.
+'twitter:description': >-
+  World's View Matobo - Cecil Rhodes' grave with spectacular sunset views over granite formations.
+canonical: 'https://travel-info.co.zw/scenic/worlds-view-matobo'
+'article:modified_time': '2025-12-30T00:00:00Z'
+'og:title': World's View Matobo Hills | Zimbabwe Travel Information
+'og:type': "article"
+'schema:type': "TouristDestination"
 ---
 
 # World's View (Matobo)

--- a/scenic/worlds-view-matobo.mdx
+++ b/scenic/worlds-view-matobo.mdx
@@ -1,0 +1,200 @@
+---
+title: "World's View (Matobo)"
+description: "Visit World's View in Matobo Hills - Cecil Rhodes' burial site and one of Zimbabwe's most dramatic viewpoints over endless granite kopjes"
+---
+
+# World's View (Matobo)
+
+<img src="/images/scenic/worlds-view-matobo.jpg" alt="World's View Matobo Hills" />
+
+**World's View** in Matobo Hills is one of Zimbabwe's most visited viewpoints, famous as the burial site of **Cecil John Rhodes**. From this dramatic granite kopje, the view extends over an endless sea of balancing rocks and domes - a landscape unchanged for millions of years.
+
+---
+
+## Quick Facts
+
+| | |
+|---|---|
+| **Location** | Matobo National Park |
+| **Famous For** | Cecil Rhodes' grave |
+| **View** | Endless granite kopjes |
+| **Access** | Short climb from parking |
+| **Best Time** | Sunset |
+| **Entry** | Park fees apply |
+
+---
+
+## The View
+
+### What You'll See
+
+- **Granite sea** - Thousands of kopjes stretching to horizon
+- **Balancing rocks** - Natural sculptures everywhere
+- **Ancient landscape** - Billions of years old
+- **Wilderness** - Matobo's protected wilderness
+- **Wildlife** - Occasionally visible from summit
+
+### Unique Character
+
+Unlike Nyanga's mountain views, World's View (Matobo) shows:
+- A landscape of **granite domes and castles**
+- Natural **balancing rock sculptures**
+- The **Matobo's wild atmosphere**
+- Seemingly infinite **rock formations**
+
+---
+
+## Cecil Rhodes' Grave
+
+### History
+
+- **Cecil John Rhodes** (1853-1902)
+- Founder of Rhodesia
+- Buried here at his request
+- Chose this spot for its grandeur
+
+### The Burial Site
+
+- Simple brass plaque on bare granite
+- No elaborate monument
+- Flat rock as grave marker
+- Panoramic setting
+
+### Other Graves Nearby
+
+- **Leander Starr Jameson** - Rhodes' friend
+- **Major Allan Wilson** - Shangani Patrol
+- **Shangani Patrol memorial** - 1893 battle
+
+### Historical Context
+
+<Note>
+Rhodes was a controversial figure - a colonizer responsible for dispossession and oppression. His burial here is part of Zimbabwe's complex colonial history. The site is historically significant but does not require celebration.
+</Note>
+
+---
+
+## Getting There
+
+### From Bulawayo
+
+1. Enter Matobo National Park (main gate)
+2. Follow signs to World's View
+3. Approximately 35 km from Bulawayo
+4. Well-signposted route
+
+### From Maleme Camp
+
+- Distance: ~15 km
+- Good park road
+- 20-30 minutes drive
+
+---
+
+## Visiting the Viewpoint
+
+### The Climb
+
+| | |
+|---|---|
+| **Distance** | ~500 meters from parking |
+| **Difficulty** | Easy-moderate |
+| **Steps** | Some stone steps |
+| **Time** | 10-15 minutes up |
+
+### At the Summit
+
+- Flat rock viewing area
+- Space for many visitors
+- Grave markers visible
+- 360-degree views
+
+---
+
+## Best Times
+
+### Time of Day
+
+| Time | Experience |
+|------|------------|
+| **Sunrise** | Dramatic, cool, quiet |
+| **Midday** | Hot, harsh light |
+| **Late afternoon** | Warming light |
+| **Sunset** | Most popular, spectacular |
+
+### Why Sunset is Best
+
+- Golden light on granite
+- Long shadows define rocks
+- Magical atmosphere
+- Photographer's paradise
+- Cooler temperature
+
+---
+
+## Photography
+
+### Tips
+
+- **Sunset** is prime time
+- **Wide angle** for panoramas
+- **Silhouettes** of rock forms
+- **Include grave** for context
+- **Tripod** for low light
+
+### Classic Shots
+
+1. Panorama at golden hour
+2. Grave with rock backdrop
+3. Silhouetted balancing rocks
+4. Sun setting through granite
+
+---
+
+## What to Bring
+
+- Camera
+- Warm layer (sunset can be cool)
+- Water
+- Comfortable shoes for climb
+- Tripod for photographers
+
+---
+
+## Combining Visits
+
+### Half-Day from Bulawayo
+
+**Afternoon:**
+- 2pm: Enter Matobo
+- 3pm: Quick rock art site
+- 5pm: Arrive World's View
+- Sunset: Photography
+- Return to Bulawayo
+
+### Full Matobo Day
+
+**Morning:**
+- Rock art sites (Nswatugi, Pomongwe)
+
+**Afternoon:**
+- Rhino tracking or game drive
+- Tea break
+
+**Evening:**
+- Sunset at World's View
+
+---
+
+## Nearby Attractions
+
+| Attraction | Distance | Highlights |
+|------------|----------|------------|
+| Nswatugi Cave | 10 km | Famous rock art |
+| Maleme Rest Camp | 15 km | Accommodation |
+| Pomongwe Cave | 12 km | Archaeological site |
+| Rhino tracking | Various | White rhino walks |
+
+<Card title="Where Worlds Meet" icon="sun">
+World's View represents where the colonial past meets ancient landscape - Rhodes chose this spot to rest for eternity amid formations that were ancient before humans existed. The view is timeless, even if the history is complicated.
+</Card>

--- a/scenic/worlds-view-nyanga.mdx
+++ b/scenic/worlds-view-nyanga.mdx
@@ -1,0 +1,146 @@
+---
+title: "World's View (Nyanga)"
+description: "Experience World's View in Nyanga National Park - a stunning viewpoint overlooking the Eastern Highlands with views stretching to Mozambique"
+---
+
+# World's View (Nyanga)
+
+<img src="/images/scenic/worlds-view-nyanga.jpg" alt="World's View Nyanga" />
+
+**World's View** in Nyanga National Park offers one of Zimbabwe's most spectacular panoramas. From this high point in the Eastern Highlands, you can see across endless mountain ridges, valleys, and on clear days, all the way to Mozambique.
+
+---
+
+## Quick Facts
+
+| | |
+|---|---|
+| **Altitude** | ~2,100 meters |
+| **Location** | Nyanga National Park |
+| **Views** | 360 degrees |
+| **Access** | Drive + short walk |
+| **Best Time** | Clear mornings |
+| **Entry** | Park fees apply |
+
+---
+
+## The View
+
+### What You'll See
+
+- **Endless ridges** - Wave after wave of mountains
+- **Deep valleys** - Dramatic drops below
+- **Mozambique** - On clear days, border mountains visible
+- **Nyangani** - Zimbabwe's highest peak in distance
+- **Sunrise/sunset** - Spectacular light shows
+
+### Directions
+
+| Direction | Features |
+|-----------|----------|
+| **East** | Honde Valley, Mozambique border |
+| **North** | Nyangani, higher peaks |
+| **South** | Troutbeck area |
+| **West** | Highland plateau |
+
+---
+
+## Getting There
+
+### From Nyanga Village
+
+1. Enter Nyanga National Park
+2. Follow main park road
+3. Watch for World's View signage
+4. Drive scenic mountain road
+5. Park at viewpoint
+
+**Distance:** ~15 km from Nyanga gate
+**Road:** Good, but winding mountain road
+
+### From Harare
+
+- **Distance:** ~280 km
+- **Time:** 4-5 hours
+- **Route:** Via Rusape to Nyanga
+
+---
+
+## Best Times
+
+### Time of Day
+
+| Time | Experience |
+|------|------------|
+| **Sunrise** | Dramatic, but requires early start |
+| **Morning (8-10am)** | Best clarity before mist |
+| **Sunset** | Golden light, often misty |
+| **Night** | Star viewing (if clear) |
+
+### Season
+
+| Season | Conditions |
+|--------|------------|
+| **May-Aug** | Clearest skies |
+| **Sep-Oct** | Dry, some haze |
+| **Nov-Feb** | Rainy, afternoon storms |
+| **Mar-Apr** | Clearing, good views |
+
+---
+
+## At the Viewpoint
+
+### Facilities
+
+- Parking area
+- Short walk to viewpoint
+- Seating/viewing platform
+- No food/shops
+
+### What to Bring
+
+- Warm jacket (altitude = cool)
+- Camera
+- Binoculars
+- Snacks/drinks
+- Patience for clouds to clear
+
+---
+
+## Photography
+
+### Tips
+
+- **Wide angle** essential
+- **Dawn** for dramatic skies
+- **Telephoto** for distant details
+- **Layers** make interesting compositions
+- **Silhouettes** at sunset
+
+---
+
+## Not to Confuse
+
+Zimbabwe has **two** "World's Views":
+
+| | Nyanga | Matobo |
+|---|--------|--------|
+| **Province** | Manicaland | Matabeleland |
+| **Character** | Mountain panorama | Granite kopjes |
+| **Famous For** | Views | Cecil Rhodes grave |
+| **Best Time** | Morning | Sunset |
+
+---
+
+## Nearby Attractions
+
+| Attraction | Distance | Highlights |
+|------------|----------|------------|
+| Mount Nyangani | 10 km | Highest peak hike |
+| Mtarazi Falls | 15 km | Highest waterfall |
+| Troutbeck | 20 km | Resort, trout fishing |
+| Pungwe Falls | 25 km | Scenic waterfall |
+
+<Card title="Top of Zimbabwe" icon="mountain">
+World's View is about more than just the view - it's the feeling of being on top of Zimbabwe, with the highlands stretching endlessly in every direction. On a clear morning, the sense of space is extraordinary.
+</Card>

--- a/scenic/worlds-view-nyanga.mdx
+++ b/scenic/worlds-view-nyanga.mdx
@@ -1,6 +1,25 @@
 ---
 title: "World's View (Nyanga)"
-description: "Experience World's View in Nyanga National Park - a stunning viewpoint overlooking the Eastern Highlands with views stretching to Mozambique"
+description: >-
+  Experience World's View in Nyanga National Park - a stunning viewpoint overlooking the Eastern Highlands with views stretching to Mozambique
+'og:image': 'https://travel-info.co.zw/images/hero-light.svg'
+'og:site_name': "Zimbabwe Travel Information"
+'twitter:card': "summary_large_image"
+'twitter:site': '@zimbabwetravel'
+'twitter:creator': '@zimbabwetravel'
+robots: 'index, follow'
+author: "Zimbabwe Travel Information"
+keywords: >-
+  worlds view nyanga, nyanga viewpoint, eastern highlands panorama, mozambique views zimbabwe, nyanga national park viewpoint
+'og:description': >-
+  World's View in Nyanga - stunning viewpoint overlooking the Eastern Highlands with views to Mozambique.
+'twitter:description': >-
+  World's View Nyanga - spectacular panoramic viewpoint in the Eastern Highlands.
+canonical: 'https://travel-info.co.zw/scenic/worlds-view-nyanga'
+'article:modified_time': '2025-12-30T00:00:00Z'
+'og:title': World's View Nyanga | Zimbabwe Travel Information
+'og:type': "article"
+'schema:type': "TouristDestination"
 ---
 
 # World's View (Nyanga)


### PR DESCRIPTION
New content categories:
- UNESCO World Heritage Sites (overview + Khami Ruins)
- Ancient Ruins (Naletale, Dhlo Dhlo, Ziwa, minor ruins)
- Rock Art (overview, Matobo, Nswatugi, Pomongwe, Chikupo, Zombepata, Mashonaland sites)
- Geological Wonders (overview, balancing rocks, Ngomakurira)
- Scenic Viewpoints (World's View Nyanga/Matobo, Chilojo Cliffs)
- Waterfalls (Mtarazi, Pungwe, Bridal Veil)
- Historic Sites (overview, colonial buildings)

Created 24 new content pages focusing on:
- Individual site pages rather than bundled overview pages
- UNESCO sites Zimbabwe was missing (Khami)
- Rock art sites with detailed visitor information
- Geological features and viewpoints
- Waterfalls and scenic attractions

Updated docs.json navigation with new Heritage & History tab.