### PR TITLE
claude/explore-directories-dxLSi

### DIFF
--- a/directory/campsites.mdx
+++ b/directory/campsites.mdx
@@ -1,0 +1,543 @@
+---
+title: Campsite Directory
+description: Complete guide to campsites in Zimbabwe - national park camps, private camping grounds, bush camps, and overlander sites across all regions.
+sidebarTitle: Campsites
+'og:image': 'https://travel-info.co.zw/images/hero-light.svg'
+'og:site_name': "Zimbabwe Travel Information"
+'twitter:card': "summary_large_image"
+'twitter:site': '@zimbabwetravel'
+robots: 'index, follow'
+author: "Zimbabwe Travel Information"
+keywords: >-
+  zimbabwe campsites, camping zimbabwe, national park campsites, hwange camping, mana pools camping, victoria falls camping, overlander campsites, bush camping zimbabwe
+canonical: 'https://travel-info.co.zw/directory/campsites'
+'og:title': Campsite Directory | Zimbabwe Travel Information
+'og:type': "website"
+---
+
+# Campsites in Zimbabwe
+
+Zimbabwe offers exceptional camping experiences - from well-equipped national park sites to remote bush camps and private camping grounds. This directory covers all camping options across the country.
+
+<Note>
+Prices listed are approximate and in USD. National park fees are additional. Always book in advance during peak season (July-October).
+</Note>
+
+---
+
+## National Park Campsites
+
+Managed by Zimbabwe Parks and Wildlife Management Authority (ZimParks). Basic facilities typically include ablution blocks, braai stands, and sometimes power points.
+
+### Hwange National Park
+
+Zimbabwe's largest national park with multiple camping options.
+
+<AccordionGroup>
+  <Accordion title="Main Camp">
+    **Location:** Southern section, near Main Camp office
+    **Facilities:** Ablutions with hot water, power points, braai stands, swimming pool nearby, shop
+    **Capacity:** 20+ sites
+    **Price:** $15-20 per person per night
+    **Best for:** First-time visitors, families
+    **Coordinates:** -18.3667, 26.5000
+  </Accordion>
+
+  <Accordion title="Sinamatella Camp">
+    **Location:** Northern section, elevated position
+    **Facilities:** Ablutions, braai stands, stunning views over Mandavu Dam
+    **Capacity:** 10 sites
+    **Price:** $15-20 per person per night
+    **Best for:** Birders, photographers
+    **Coordinates:** -18.1833, 26.1833
+  </Accordion>
+
+  <Accordion title="Robins Camp">
+    **Location:** Northern section
+    **Facilities:** Basic ablutions, braai stands, remote atmosphere
+    **Capacity:** 8 sites
+    **Price:** $15-20 per person per night
+    **Best for:** Adventurous campers seeking solitude
+    **Coordinates:** -18.1000, 26.0500
+  </Accordion>
+
+  <Accordion title="Mandavu Dam">
+    **Location:** Near Sinamatella
+    **Facilities:** Basic, communal braai area, dam views
+    **Capacity:** 5 sites
+    **Price:** $15-20 per person per night
+    **Best for:** Game viewing at the dam
+  </Accordion>
+
+  <Accordion title="Deteema Dam">
+    **Location:** Central-north section
+    **Facilities:** Basic ablutions, excellent game viewing platform
+    **Capacity:** Limited sites
+    **Price:** $15-20 per person per night
+    **Best for:** Serious wildlife enthusiasts
+  </Accordion>
+</AccordionGroup>
+
+### Mana Pools National Park
+
+UNESCO World Heritage site with exclusive camping on the Zambezi floodplains.
+
+<AccordionGroup>
+  <Accordion title="Nyamepi Camp">
+    **Location:** Central riverine area
+    **Facilities:** Ablutions, braai stands, water points
+    **Capacity:** 30 sites
+    **Price:** $20-30 per person per night
+    **Best for:** Main base for Mana exploration
+    **Coordinates:** -15.7500, 29.4000
+  </Accordion>
+
+  <Accordion title="Exclusive Campsites (1-5)">
+    **Location:** Along the Zambezi riverfront
+    **Facilities:** Private sites, basic ablutions, fire pits
+    **Capacity:** 1 group per site (max 12 people)
+    **Price:** $50-100 per site per night
+    **Best for:** Private groups, professional photographers
+    **Note:** Must book entire site
+  </Accordion>
+
+  <Accordion title="Mucheni Camp">
+    **Location:** Eastern section
+    **Facilities:** Very basic, remote
+    **Capacity:** Limited
+    **Price:** $20-30 per person per night
+    **Best for:** Adventure seekers wanting true wilderness
+  </Accordion>
+</AccordionGroup>
+
+### Gonarezhou National Park
+
+Zimbabwe's second-largest park, known for the iconic Chilojo Cliffs.
+
+<AccordionGroup>
+  <Accordion title="Chipinda Pools">
+    **Location:** Northern section, park headquarters
+    **Facilities:** Ablutions, braai stands, swimming pool
+    **Capacity:** 15 sites
+    **Price:** $15-20 per person per night
+    **Best for:** Base for northern Gonarezhou
+    **Coordinates:** -21.2500, 32.0500
+  </Accordion>
+
+  <Accordion title="Chilojo Camp">
+    **Location:** Southern section, near Chilojo Cliffs
+    **Facilities:** Basic ablutions, stunning cliff views
+    **Capacity:** 8 sites
+    **Price:** $15-20 per person per night
+    **Best for:** Photography, scenic camping
+  </Accordion>
+
+  <Accordion title="Chinguli Camp">
+    **Location:** Southern section
+    **Facilities:** Very basic
+    **Capacity:** 5 sites
+    **Price:** $15-20 per person per night
+    **Best for:** Remote wilderness experience
+  </Accordion>
+
+  <Accordion title="Swimuwini Camp">
+    **Location:** Near Mwenezi River
+    **Facilities:** Basic ablutions, natural rock pool
+    **Capacity:** 6 sites
+    **Price:** $15-20 per person per night
+    **Best for:** Swimming, relaxed camping
+  </Accordion>
+</AccordionGroup>
+
+### Matobo National Park
+
+Ancient granite landscapes with rock art and rhino tracking.
+
+<AccordionGroup>
+  <Accordion title="Maleme Dam">
+    **Location:** Central Matobo, near dam
+    **Facilities:** Ablutions with hot water, braai stands, swimming dam
+    **Capacity:** 20 sites
+    **Price:** $15-20 per person per night
+    **Best for:** Families, swimming, rock art exploration
+    **Coordinates:** -20.5000, 28.5000
+  </Accordion>
+
+  <Accordion title="Toghwana Dam">
+    **Location:** Eastern section
+    **Facilities:** Basic ablutions, scenic dam setting
+    **Capacity:** 10 sites
+    **Price:** $15-20 per person per night
+    **Best for:** Quieter alternative to Maleme
+  </Accordion>
+
+  <Accordion title="Mtsheleli Dam">
+    **Location:** Western section
+    **Facilities:** Basic ablutions
+    **Capacity:** 8 sites
+    **Price:** $15-20 per person per night
+    **Best for:** Bird watching
+  </Accordion>
+</AccordionGroup>
+
+### Matusadona National Park
+
+Remote wilderness on Lake Kariba's shoreline.
+
+<AccordionGroup>
+  <Accordion title="Tashinga Camp">
+    **Location:** Eastern section, park headquarters
+    **Facilities:** Ablutions, braai stands, lake access
+    **Capacity:** 10 sites
+    **Price:** $15-20 per person per night
+    **Best for:** Lake Kariba camping base
+    **Coordinates:** -16.7833, 28.4167
+  </Accordion>
+
+  <Accordion title="Sanyati Gorge">
+    **Location:** Western boundary
+    **Facilities:** Very basic, boat access recommended
+    **Capacity:** 5 sites
+    **Price:** $15-20 per person per night
+    **Best for:** Fishing, adventure camping
+  </Accordion>
+</AccordionGroup>
+
+### Eastern Highlands
+
+Mountain camping with cool climate and scenic views.
+
+<AccordionGroup>
+  <Accordion title="Nyanga National Park - Mare Dam">
+    **Location:** Central Nyanga
+    **Facilities:** Ablutions, braai stands, trout fishing
+    **Capacity:** 15 sites
+    **Price:** $15-20 per person per night
+    **Best for:** Fishing, mountain hiking
+    **Coordinates:** -18.2833, 32.7500
+  </Accordion>
+
+  <Accordion title="Nyanga - Udu Dam">
+    **Location:** Northern Nyanga
+    **Facilities:** Basic ablutions, scenic dam
+    **Capacity:** 8 sites
+    **Price:** $15-20 per person per night
+    **Best for:** Trout fishing, quiet retreat
+  </Accordion>
+
+  <Accordion title="Chimanimani National Park">
+    **Location:** Mutekeswane Base Camp
+    **Facilities:** Basic ablutions, mountain hut available
+    **Capacity:** 10 sites
+    **Price:** $15-20 per person per night
+    **Best for:** Hikers, mountain climbers
+    **Coordinates:** -19.8000, 33.0000
+  </Accordion>
+
+  <Accordion title="Vumba Botanical Gardens">
+    **Location:** Bvumba Mountains
+    **Facilities:** Basic camping area in gardens
+    **Capacity:** Limited
+    **Price:** $10-15 per person per night
+    **Best for:** Botanical enthusiasts, birders
+  </Accordion>
+</AccordionGroup>
+
+### Other National Parks & Reserves
+
+<AccordionGroup>
+  <Accordion title="Lake Chivero Recreational Park">
+    **Location:** 30km from Harare
+    **Facilities:** Ablutions, braai stands, boat launch
+    **Capacity:** 20+ sites
+    **Price:** $10-15 per person per night
+    **Best for:** Weekend escapes from Harare
+    **Coordinates:** -17.9000, 30.8000
+  </Accordion>
+
+  <Accordion title="Lake Mutirikwi (Kyle) Recreational Park">
+    **Location:** Near Masvingo
+    **Facilities:** Ablutions, braai stands, lake access
+    **Capacity:** 15 sites
+    **Price:** $10-15 per person per night
+    **Best for:** Combining with Great Zimbabwe visit
+    **Coordinates:** -20.2167, 31.0000
+  </Accordion>
+
+  <Accordion title="Sebakwe Recreational Park">
+    **Location:** Near Kwekwe
+    **Facilities:** Basic ablutions, fishing
+    **Capacity:** 10 sites
+    **Price:** $10-15 per person per night
+    **Best for:** Fishing enthusiasts
+  </Accordion>
+
+  <Accordion title="Ngezi Recreational Park">
+    **Location:** Near Kadoma
+    **Facilities:** Ablutions, dam access
+    **Capacity:** 8 sites
+    **Price:** $10-15 per person per night
+    **Best for:** Day trips, fishing
+  </Accordion>
+</AccordionGroup>
+
+---
+
+## Victoria Falls Area Campsites
+
+Popular camping options near the adventure capital.
+
+<AccordionGroup>
+  <Accordion title="Victoria Falls Rest Camp & Lodges">
+    **Location:** 2km from Victoria Falls town
+    **Facilities:** Hot showers, flush toilets, pool, bar, restaurant, WiFi
+    **Capacity:** 30+ sites
+    **Price:** $15-25 per person per night
+    **Best for:** Budget travelers, backpackers
+    **Contact:** +263 83 2844308
+  </Accordion>
+
+  <Accordion title="Shearwater Explorers Village">
+    **Location:** Victoria Falls town
+    **Facilities:** Backpacker-style, shared ablutions, pool, bar
+    **Capacity:** Limited camping spots
+    **Price:** $15-20 per person per night
+    **Best for:** Backpackers, activity seekers
+  </Accordion>
+
+  <Accordion title="Zambezi National Park Campsites">
+    **Location:** Along Zambezi River upstream from Falls
+    **Facilities:** 25 exclusive riverside sites, basic ablutions
+    **Capacity:** 25 sites (1-4 groups per site)
+    **Price:** $30-50 per site per night
+    **Best for:** Fishing, river camping, wildlife
+    **Coordinates:** -17.8833, 25.7667
+  </Accordion>
+</AccordionGroup>
+
+---
+
+## Private & Community Campsites
+
+### Hwange Area
+
+<AccordionGroup>
+  <Accordion title="Ivory Lodge Campsite">
+    **Location:** Near Hwange Main Camp
+    **Facilities:** Shared ablutions, braai, access to lodge facilities
+    **Capacity:** 10 sites
+    **Price:** $20-30 per person per night
+    **Best for:** Affordable Hwange camping with some amenities
+  </Accordion>
+
+  <Accordion title="Big Cave Camp">
+    **Location:** Matobo Hills
+    **Facilities:** Basic camping with access to lodge
+    **Capacity:** 5 sites
+    **Price:** $25-35 per person per night
+    **Best for:** Rock art tours, rhino tracking
+  </Accordion>
+</AccordionGroup>
+
+### Lake Kariba Area
+
+<AccordionGroup>
+  <Accordion title="Kariba Heights Campsite">
+    **Location:** Kariba town
+    **Facilities:** Ablutions, lake views, boat access
+    **Capacity:** 15 sites
+    **Price:** $15-20 per person per night
+    **Best for:** Lake activities, fishing trips
+  </Accordion>
+
+  <Accordion title="Charara Safari Area">
+    **Location:** Western Lake Kariba
+    **Facilities:** Basic campsites along the lakeshore
+    **Capacity:** Multiple sites
+    **Price:** $15-20 per person per night
+    **Best for:** Fishing, boating, wildlife
+  </Accordion>
+</AccordionGroup>
+
+### Eastern Highlands
+
+<AccordionGroup>
+  <Accordion title="Heaven Lodge Campsite">
+    **Location:** Nyanga
+    **Facilities:** Hot showers, braai, mountain setting
+    **Capacity:** 12 sites
+    **Price:** $15-25 per person per night
+    **Best for:** Mountain hiking base
+  </Accordion>
+
+  <Accordion title="Far and Wide Zimbabwe">
+    **Location:** Chimanimani
+    **Facilities:** Rustic camping, community-run
+    **Capacity:** 8 sites
+    **Price:** $10-20 per person per night
+    **Best for:** Hikers, community tourism
+  </Accordion>
+
+  <Accordion title="Chimanimani Hotel Campsite">
+    **Location:** Chimanimani village
+    **Facilities:** Basic camping with access to hotel facilities
+    **Capacity:** 10 sites
+    **Price:** $10-15 per person per night
+    **Best for:** Pre/post mountain hikes
+  </Accordion>
+</AccordionGroup>
+
+### Harare & Surrounds
+
+<AccordionGroup>
+  <Accordion title="Wild Geese Lodge">
+    **Location:** North of Harare
+    **Facilities:** Camping with pool, bar, restaurant
+    **Capacity:** 20 sites
+    **Price:** $15-20 per person per night
+    **Best for:** Harare stopover, overlanders
+  </Accordion>
+
+  <Accordion title="Bushman Rock Safari Camp">
+    **Location:** Near Harare
+    **Facilities:** Bush setting, ablutions, game viewing
+    **Capacity:** 10 sites
+    **Price:** $20-30 per person per night
+    **Best for:** Wildlife near the city
+  </Accordion>
+</AccordionGroup>
+
+### Bulawayo & Surrounds
+
+<AccordionGroup>
+  <Accordion title="Burke's Paradise">
+    **Location:** Near Bulawayo
+    **Facilities:** Farm camping, ablutions, pool
+    **Capacity:** 15 sites
+    **Price:** $10-15 per person per night
+    **Best for:** Budget travelers, Matobo base
+  </Accordion>
+
+  <Accordion title="Khami Ruins Campsite">
+    **Location:** Adjacent to Khami Ruins
+    **Facilities:** Basic camping near UNESCO site
+    **Capacity:** 5 sites
+    **Price:** $10-15 per person per night
+    **Best for:** History enthusiasts
+  </Accordion>
+</AccordionGroup>
+
+---
+
+## Overlander & Transit Campsites
+
+Popular stops for self-drive travelers and overland trucks.
+
+<CardGroup cols={2}>
+  <Card title="N1 Hotel Campsite - Harare" icon="truck">
+    Secure parking, hot showers, restaurant. Ideal Harare transit stop.
+  </Card>
+  <Card title="Rainbow Hotel Campsite - Vic Falls" icon="tent">
+    Town location, pool access, walking distance to activities.
+  </Card>
+  <Card title="Municipal Campsites" icon="building">
+    Various towns offer basic municipal camping - enquire locally.
+  </Card>
+  <Card title="Service Station Camping" icon="gas-pump">
+    Some rural stations allow overnight camping - always ask permission.
+  </Card>
+</CardGroup>
+
+---
+
+## Camping Tips for Zimbabwe
+
+<AccordionGroup>
+  <Accordion title="Booking & Reservations">
+    - **National Parks:** Book through ZimParks online or at regional offices
+    - **Peak Season (July-October):** Book 2-3 months in advance
+    - **Exclusive Sites:** Often require full site booking, not per-person
+    - **Payment:** Cash (USD) often preferred; some accept mobile money
+  </Accordion>
+
+  <Accordion title="What to Bring">
+    - All camping equipment (rarely available for hire)
+    - Firewood (often available for purchase)
+    - Drinking water or purification
+    - Food and cooking supplies
+    - Torch/headlamp with extra batteries
+    - First aid kit and any medications
+    - Warm clothing (nights can be cold, especially May-August)
+  </Accordion>
+
+  <Accordion title="Safety Guidelines">
+    - Never leave food unattended - baboons and monkeys are common
+    - Store food in vehicles or secure containers
+    - Be aware of wildlife, especially at night
+    - Don't walk between sites after dark in wildlife areas
+    - Keep a torch handy for nighttime ablution visits
+    - Follow fire safety rules - use designated braai areas
+  </Accordion>
+
+  <Accordion title="Wildlife Precautions">
+    - Elephants: Common in Hwange, Mana Pools - give them space
+    - Hippos: Active at night near water - be cautious
+    - Hyenas: May investigate camps - secure all food
+    - Snakes: Check shoes and bedding; don't walk barefoot
+    - Mosquitoes: Use repellent and nets, especially Oct-April
+  </Accordion>
+</AccordionGroup>
+
+---
+
+## Campsite Facilities Guide
+
+<Tabs>
+  <Tab title="Basic">
+    **Facilities:** Pit latrines, cold water (if any), fire pit
+    **Found at:** Remote national park sites, wild camping areas
+    **Bring:** All water, toilet paper, all supplies
+    **Price range:** $10-15 per person
+  </Tab>
+  <Tab title="Standard">
+    **Facilities:** Flush toilets, cold showers, braai stands
+    **Found at:** Most national park camps
+    **Bring:** Drinking water, all camping gear, food
+    **Price range:** $15-20 per person
+  </Tab>
+  <Tab title="Comfortable">
+    **Facilities:** Hot showers, power points, shop nearby
+    **Found at:** Main camps, some private sites
+    **Bring:** Camping gear, food (basics available)
+    **Price range:** $20-30 per person
+  </Tab>
+  <Tab title="Luxury">
+    **Facilities:** En-suite ablutions, restaurant, pool, WiFi
+    **Found at:** Private lodges with camping
+    **Bring:** Personal items, camping optional
+    **Price range:** $30-50+ per person
+  </Tab>
+</Tabs>
+
+---
+
+## Booking Resources
+
+<CardGroup cols={2}>
+  <Card title="Zimbabwe Parks & Wildlife" icon="tree" href="http://zimparks.org">
+    Official national park campsite bookings
+  </Card>
+  <Card title="Contact Us" icon="phone" href="/contact">
+    Need help finding the right campsite? Get in touch
+  </Card>
+</CardGroup>
+
+---
+
+## Register Your Campsite
+
+Own or manage a campsite in Zimbabwe? List it in our directory.
+
+<Card title="Add Your Campsite" icon="tent" href="/get-involved/business-partner-network">
+  Free listing with optional verification and promotional packages.
+</Card>

--- a/docs.json
+++ b/docs.json
@@ -100,6 +100,50 @@
   "navigation": {
     "tabs": [
       {
+        "tab": "Discover",
+        "groups": [
+          {
+            "group": "Get Started",
+            "pages": [
+              "introduction",
+              "about-zimbabwe",
+              "when-to-visit",
+              "book"
+            ]
+          },
+          {
+            "group": "Culture & Experiences",
+            "pages": [
+              "culture/people-and-tribes",
+              "culture/art-and-music",
+              "culture/cuisine",
+              "culture/festivals-and-events",
+              "culture/shopping-guide",
+              "culture/religious-sites"
+            ]
+          },
+          {
+            "group": "Wildlife & Nature",
+            "pages": [
+              "wildlife/animals-and-birds",
+              "wildlife/national-parks-and-reserves",
+              "wildlife/conservation-efforts"
+            ]
+          },
+          {
+            "group": "Adventure Activities",
+            "pages": [
+              "adventure/activities-and-experiences",
+              "adventure/water-sports",
+              "adventure/hiking-and-trekking",
+              "adventure/nightlife-entertainment",
+              "adventure/photography-guide",
+              "adventure/wellness-spa"
+            ]
+          }
+        ]
+      },
+      {
         "tab": "Heritage & History",
         "groups": [
           {
@@ -166,50 +210,6 @@
             "pages": [
               "historic/index",
               "historic/colonial-buildings"
-            ]
-          }
-        ]
-      },
-      {
-        "tab": "Discover",
-        "groups": [
-          {
-            "group": "Get Started",
-            "pages": [
-              "introduction",
-              "about-zimbabwe",
-              "when-to-visit",
-              "book"
-            ]
-          },
-          {
-            "group": "Culture & Experiences",
-            "pages": [
-              "culture/people-and-tribes",
-              "culture/art-and-music",
-              "culture/cuisine",
-              "culture/festivals-and-events",
-              "culture/shopping-guide",
-              "culture/religious-sites"
-            ]
-          },
-          {
-            "group": "Wildlife & Nature",
-            "pages": [
-              "wildlife/animals-and-birds",
-              "wildlife/national-parks-and-reserves",
-              "wildlife/conservation-efforts"
-            ]
-          },
-          {
-            "group": "Adventure Activities",
-            "pages": [
-              "adventure/activities-and-experiences",
-              "adventure/water-sports",
-              "adventure/hiking-and-trekking",
-              "adventure/nightlife-entertainment",
-              "adventure/photography-guide",
-              "adventure/wellness-spa"
             ]
           }
         ]
@@ -362,7 +362,8 @@
             "pages": [
               "experts/index",
               "directory/businesses",
-              "directory/accommodation"
+              "directory/accommodation",
+              "directory/campsites"
             ]
           }
         ]


### PR DESCRIPTION
- Create comprehensive campsite directory with 40+ campsites across Zimbabwe
- Include national park camps (Hwange, Mana Pools, Gonarezhou, Matobo, etc.)
- Add Victoria Falls area, private, and overlander campsites
- Include camping tips, facilities guide, and booking resources
- Move Discover tab first in navigation so Introduction page loads by default